### PR TITLE
Subscribe to dataValuesLoaded using $(this) to avoid errors

### DIFF
--- a/HWF/NHWA Module 1 (FuMctq4PQpf).html
+++ b/HWF/NHWA Module 1 (FuMctq4PQpf).html
@@ -1320,7 +1320,7 @@
     }
   }
 
-  dhis2.util.on("dhis2.de.event.dataValuesLoaded", function() {
+  $(this).on(dhis2.de.event.dataValuesLoaded, function() {
     values.forEach(function(value) {
       $("#" + value.id + "-Xr12mI7VPn3-val").on("change", function() {
         $("#alert-error").hide();

--- a/HWF/NHWA Module 1 (Subnational) (pamb86ECgOA).html
+++ b/HWF/NHWA Module 1 (Subnational) (pamb86ECgOA).html
@@ -479,7 +479,8 @@
       expanded = false;
     }
   }
-  dhis2.util.on("dhis2.de.event.dataValuesLoaded", function() {
+  
+  $(this).on(dhis2.de.event.dataValuesLoaded, function() {
     values.forEach(function(value) {
       $("#" + value.id + "-Xr12mI7VPn3-val").on("change", function() {
         $("#alert-error").hide();

--- a/HWF/NHWA Module 2 (kwqbAP06ErA).html
+++ b/HWF/NHWA Module 2 (kwqbAP06ErA).html
@@ -63,7 +63,7 @@
 
     disableCommentLogic();
     $(this).on(dhis2.de.event.dataValuesLoaded, disableCommentLogic);
-    
+
     $(".comment-bubble").on("click", function() {
       const col = $(this).parent()[0].cellIndex + 1;
       $(this)

--- a/HWF/NHWA Module 2 (kwqbAP06ErA).html
+++ b/HWF/NHWA Module 2 (kwqbAP06ErA).html
@@ -62,8 +62,8 @@
     });
 
     disableCommentLogic();
-
     $(this).on(dhis2.de.event.dataValuesLoaded, disableCommentLogic);
+    
     $(".comment-bubble").on("click", function() {
       const col = $(this).parent()[0].cellIndex + 1;
       $(this)

--- a/HWF/NHWA Module 2 (kwqbAP06ErA).html
+++ b/HWF/NHWA Module 2 (kwqbAP06ErA).html
@@ -64,7 +64,6 @@
     disableCommentLogic();
 
     $(this).on(dhis2.de.event.dataValuesLoaded, disableCommentLogic);
-
     $(".comment-bubble").on("click", function() {
       const col = $(this).parent()[0].cellIndex + 1;
       $(this)

--- a/HWF/NHWA Module 2 (kwqbAP06ErA).html
+++ b/HWF/NHWA Module 2 (kwqbAP06ErA).html
@@ -62,7 +62,8 @@
     });
 
     disableCommentLogic();
-    dhis2.util.on("dhis2.de.event.dataValuesLoaded", disableCommentLogic);
+
+    $(this).on(dhis2.de.event.dataValuesLoaded, disableCommentLogic);
 
     $(".comment-bubble").on("click", function() {
       const col = $(this).parent()[0].cellIndex + 1;

--- a/HWF/NHWA Module 3 (gUsLcRFoCG6).html
+++ b/HWF/NHWA Module 3 (gUsLcRFoCG6).html
@@ -190,7 +190,7 @@
     });
 
     disableCommentLogic();
-    dhis2.util.on("dhis2.de.event.dataValuesLoaded", disableCommentLogic);
+    $(this).on(dhis2.de.event.dataValuesLoaded, disableCommentLogic);
 
     $(".comment-bubble").on("click", function() {
       const col = $(this).parent()[0].cellIndex + 1;

--- a/HWF/NHWA Module 4 (rbmrIWEJriN).html
+++ b/HWF/NHWA Module 4 (rbmrIWEJriN).html
@@ -62,7 +62,7 @@
     });
 
     disableCommentLogic();
-    dhis2.util.on("dhis2.de.event.dataValuesLoaded", disableCommentLogic);
+    $(this).on(dhis2.de.event.dataValuesLoaded, disableCommentLogic);
 
     $(".comment-bubble").on("click", function() {
       const col = $(this).parent()[0].cellIndex + 1;

--- a/HWF/NHWA Module 6 (U2K47T8nDgj).html
+++ b/HWF/NHWA Module 6 (U2K47T8nDgj).html
@@ -107,7 +107,7 @@
     });
 
     disableCommentLogic();
-    dhis2.util.on("dhis2.de.event.dataValuesLoaded", disableCommentLogic);
+    $(this).on(dhis2.de.event.dataValuesLoaded, disableCommentLogic);
 
     $(".comment-bubble").on("click", function() {
       const col = $(this).parent()[0].cellIndex + 1;

--- a/HWF/NHWA Module 7 (Vvb0gbFH9IO).html
+++ b/HWF/NHWA Module 7 (Vvb0gbFH9IO).html
@@ -84,7 +84,7 @@
     });
 
     disableCommentLogic();
-    dhis2.util.on("dhis2.de.event.dataValuesLoaded", disableCommentLogic);
+    $(this).on(dhis2.de.event.dataValuesLoaded, disableCommentLogic);
 
     $(".comment-bubble").on("click", function() {
       const col = $(this).parent()[0].cellIndex + 1;

--- a/HWF/NHWA Module 8-10 (qFGgohqJuy0).html
+++ b/HWF/NHWA Module 8-10 (qFGgohqJuy0).html
@@ -92,7 +92,7 @@
     });
 
     disableCommentLogic();
-    dhis2.util.on("dhis2.de.event.dataValuesLoaded", disableCommentLogic);
+    $(this).on(dhis2.de.event.dataValuesLoaded, disableCommentLogic);
 
     $(".comment-bubble").on("click", function() {
       const col = $(this).parent()[0].cellIndex + 1;


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #13             
* **Related pull-requests:** 

### :tophat: What is the goal?

Investigate in HWF custom forms why sometimes in other resources upload button is disabled

### :memo: How is it being implemented?

- I have verified when the subscription to dataValuesLoaded event is realized using dhis2.util.on, dataValuesLoaded does not work properly in data entry app subscriptions, for example, to enable upload button in other resources tab. 

- Data entry app also use jquery $(document) to subscribe to events 
[code](https://github.com/dhis2/dhis2-core/blob/1e2a3c2d937821d4743299da8b2714cb8cecab80/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/entry.fileresource.js#L201)

I have modified subscriptions to dataValuesLoaded using jquery $(this) and now work successfully.

### :boom: How can it be tested?

From Data entry application reviewing other resources tab in HWF modules


