### PR TITLE
Fix yes over no design requested by client

### DIFF
--- a/HWF/NHWA Module 7 (Vvb0gbFH9IO).html
+++ b/HWF/NHWA Module 7 (Vvb0gbFH9IO).html
@@ -199,6 +199,10 @@
   .commentlink {
     display: none;
   }
+
+  .yesno label {
+    display: inline;
+  }
 </style>
 <h3 style="text-align: center;">
   <strong>Health Workforce Spending and Remuneration</strong>
@@ -914,7 +918,7 @@
                 public sector wage ceiling&nbsp;(7-06)
               </p>
             </th>
-            <td style="text-align: center;">
+            <td class="yesno" style="text-align: center;">
               <input
                 id="M7R7LVsXlAN-Xr12mI7VPn3-val"
                 name="entryfield"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #15              
* **Related pull-requests:** 

### :tophat: What is the goal?

Module 7 remuneration tab last question. yes/no question layout shows strange (yes over the no...which looks like an easy-to-solve format layout). Not to implement in case it's something difficult to investigate

### :memo: How is it being implemented?

- I have created a new style to render these labels inline
### :boom: How can it be tested?

From Data entry application reviewing remuneration tab in HWF module 7

### Screenshots 
![yes_no](https://user-images.githubusercontent.com/5593590/66634378-39cd5a00-ec0d-11e9-9454-f54b92c50cbf.png)

