### PR TITLE
Script to translate data-entry and policy-uptake custom forms

### DIFF
--- a/HEP-data-entry/README.md
+++ b/HEP-data-entry/README.md
@@ -12,7 +12,7 @@ $ yarn build
 Example:
 
 ```
-$ node lib/cli.js --url='https://admin:district@play.dhis2.org/2.30' --dataset-id='eZDhcZi6FLP'
+$ node lib/cli.js --url='https://admin:district@play.dhis2.org/2.30' --dataset-id='jfawDJZ5fOX'
 ```
 
 You can also run code directly from sources using [ts-node](https://www.npmjs.com/package/ts-node):

--- a/HEP-data-entry/src/components/EntryField.tsx
+++ b/HEP-data-entry/src/components/EntryField.tsx
@@ -27,6 +27,7 @@ export function EntryField(attributes: EntryFieldAttributes): string {
             {helpMessages ? (
                 <i
                     class="fas fa-info-circle help-icon"
+                    id={`${dataElement.id}-${categoryOptionCombo.name}-field-description`}
                     title={`${helpMessages[categoryOptionCombo.name]}`}
                 ></i>
             ) : null}

--- a/HEP-data-entry/src/components/GlobalTextFields.tsx
+++ b/HEP-data-entry/src/components/GlobalTextFields.tsx
@@ -10,8 +10,12 @@ interface GlobalTextFieldAttributes {
 export function GlobalTextFields(attributes: GlobalTextFieldAttributes): string {
     const { dataElements, categoryOptionCombos } = attributes;
     const fields = _.flatMap(dataElements, de =>
-        categoryOptionCombos.map(coc => [
-            <div class="global-entry-title">{`${de.formName} for the whole ${coc.name} cascade`}</div>,
+        categoryOptionCombos.map((coc, i) => [
+            <div class="global-entry-title">
+                <span
+                    id={`${de.id}-global-dataElements-${i}`}
+                >{`${de.formName} for the whole ${coc.name} cascade`}</span>
+            </div>,
             <textarea
                 id={`${de.id}-${coc.id}-val`}
                 name="entryfield"

--- a/HEP-data-entry/src/components/Table.tsx
+++ b/HEP-data-entry/src/components/Table.tsx
@@ -62,7 +62,7 @@ function FieldsRow(attributes: {
     return (
         <tr>
             <td class={`column-big ${background} center-text`}>
-                {dataElement.formName}
+                <span id={`${dataElement.id}-dataElement`}>{dataElement.formName}</span>
                 <i class="fas fa-info-circle help-icon" title={`${helpMessages.main}`}></i>
             </td>
             {...fieldTds}
@@ -84,7 +84,9 @@ function CheckBoxGroup(attributes: {
                 categoryOptionCombo={categoryOptionCombo}
                 type="checkbox"
             />
-            <div>{de.formName}</div>
+            <div>
+                <span id={`${de.id}-dataElement`}>{de.formName}</span>
+            </div>
         </div>
     ));
     const background = Form.getCategoryOptionComboColor(categoryOptionCombo);

--- a/HEP-data-entry/src/components/Table.tsx
+++ b/HEP-data-entry/src/components/Table.tsx
@@ -63,7 +63,11 @@ function FieldsRow(attributes: {
         <tr>
             <td class={`column-big ${background} center-text`}>
                 <span id={`${dataElement.id}-dataElement`}>{dataElement.formName}</span>
-                <i class="fas fa-info-circle help-icon" title={`${helpMessages.main}`}></i>
+                <i
+                    id={`${dataElement.id}-dataElement-description`}
+                    class="fas fa-info-circle help-icon"
+                    title={`${helpMessages.main}`}
+                ></i>
             </td>
             {...fieldTds}
         </tr>

--- a/HEP-data-entry/src/components/Tabs.tsx
+++ b/HEP-data-entry/src/components/Tabs.tsx
@@ -10,6 +10,7 @@ export function Tabs(attributes: TabsAttributes): string {
     const { sections } = attributes;
     const items = sections.map(s => {
         return {
+            id: s.id,
             title: s.displayName,
             contents: <Table section={s} />,
         };
@@ -20,7 +21,7 @@ export function Tabs(attributes: TabsAttributes): string {
                 role="tablist"
                 class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header"
             >
-                {items.map(({ title }, index) => (
+                {items.map(({ title, id }, index) => (
                     <li
                         role="tab"
                         tabindex="-1"
@@ -32,7 +33,7 @@ export function Tabs(attributes: TabsAttributes): string {
                             tabindex="-1"
                             class="ui-tabs-anchor"
                         >
-                            {title}
+                            <span id={`${id}-section-title`}>{title}</span>
                         </a>
                     </li>
                 ))}

--- a/HEP-data-entry/src/resources/custom-form.js
+++ b/HEP-data-entry/src/resources/custom-form.js
@@ -53,8 +53,8 @@ function replaceLocalizedTexts(dataElementTranslations, sectionTranslations, use
             HCV: `${text} para toda la cascada HCV`,
         },
         fr: {
-            HBV: `${text} pour toute la cascade HBV`,
-            HCV: `${text} pour toute la cascade HCV`,
+            HBV: `${text} pour toute la cascade VHB`,
+            HCV: `${text} pour toute la cascade VHC`,
         },
     });
     sectionTranslations.forEach(s => {

--- a/HEP-data-entry/src/resources/custom-form.js
+++ b/HEP-data-entry/src/resources/custom-form.js
@@ -1,24 +1,21 @@
-const GLOBAL_FIELDS_TEMPLATE_SPANISH_HBV = text => `${text} para toda la cascada HBV`;
-const GLOBAL_FIELDS_TEMPLATE_SPANISH_HCV = text => `${text} para toda la cascada HCV`;
-
 async function applyChangesToForm() {
-    const {
-        dataElementTranslations,
-        sectionTranslations,
-        userLocale,
-    } = await getLocaleAndTranslations();
-    replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale);
     const datasetToApplyChanges = $("#custom-form-script").attr("data-dataset-id");
     const currentDataset = $("#selectedDataSetId").val();
     $("#completenessDiv").wrap("<div id='completenessWrapper'></div>");
     if (datasetToApplyChanges === currentDataset) {
+        const {
+            dataElementTranslations,
+            sectionTranslations,
+            userLocale,
+        } = await getLocaleAndTranslations(currentDataset);
+        replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale);
         $("#completenessWrapper").hide();
     } else {
         $("#completenessWrapper").show();
     }
 }
 
-async function getLocaleAndTranslations() {
+async function getLocaleAndTranslations(dataSetId) {
     const userLocale = await fetch("http://localhost:8080/api/userSettings.json", {
         method: "GET",
     }).then(async response => {
@@ -26,8 +23,9 @@ async function getLocaleAndTranslations() {
         const parsed = JSON.parse(body);
         return parsed.keyUiLocale;
     });
+
     const { dataElementTranslations, sectionTranslations } = await fetch(
-        "http://localhost:8080/api/dataSets.json?fields=sections[id,translations,dataElements[id,name,formName,translations]]&filter=id:eq:jfawDJZ5fOX",
+        `http://localhost:8080/api/dataSets.json?fields=sections[id,translations,dataElements[id,name,formName,translations]]&filter=id:eq:${dataSetId}`,
         { method: "GET" }
     ).then(async response => {
         const body = await response.text();
@@ -49,6 +47,16 @@ async function getLocaleAndTranslations() {
 }
 
 function replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale) {
+    const globalFieldsStaticTranslations = text => ({
+        es: {
+            HBV: `${text} para toda la cascada HBV`,
+            HCV: `${text} para toda la cascada HCV`,
+        },
+        fr: {
+            HBV: `${text} pour toute la cascade HBV`,
+            HCV: `${text} pour toute la cascade HCV`,
+        },
+    });
     sectionTranslations.forEach(s => {
         const translation = s.translations.find(
             t => t.locale === userLocale && t.property === "NAME"
@@ -61,17 +69,14 @@ function replaceLocalizedTexts(dataElementTranslations, sectionTranslations, use
         const translation = de.translations.find(
             t => t.locale === userLocale && t.property === "FORM_NAME"
         );
-        if (de.name === "HEP_CASCADE_Additional_Information") {
+        if (de.name === "HEP_CASCADE_Additional_Information" && translation) {
             $(`span[id="${de.id}-global-dataElements-0"]`).html(
-                GLOBAL_FIELDS_TEMPLATE_SPANISH_HBV(translation.value)
+                globalFieldsStaticTranslations(translation.value)[userLocale].HBV
             );
             $(`span[id="${de.id}-global-dataElements-1"]`).html(
-                GLOBAL_FIELDS_TEMPLATE_SPANISH_HCV(translation.value)
+                globalFieldsStaticTranslations(translation.value)[userLocale].HCV
             );
         } else {
-            const translation = de.translations.find(
-                t => t.locale === userLocale && t.property === "FORM_NAME"
-            );
             if (translation) {
                 $(`span[id="${de.id}-dataElement"]`).html(translation.value);
             }

--- a/HEP-data-entry/src/resources/custom-form.js
+++ b/HEP-data-entry/src/resources/custom-form.js
@@ -1,6 +1,10 @@
 async function applyChangesToForm() {
-    const { dataElementTranslations, userLocale } = await getLocaleAndTranslations();
-    await replaceDataElementTitles(dataElementTranslations, userLocale);
+    const {
+        dataElementTranslations,
+        sectionTranslations,
+        userLocale,
+    } = await getLocaleAndTranslations();
+    await replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale);
     const datasetToApplyChanges = $("#custom-form-script").attr("data-dataset-id");
     const currentDataset = $("#selectedDataSetId").val();
     $("#completenessDiv").wrap("<div id='completenessWrapper'></div>");
@@ -19,21 +23,37 @@ async function getLocaleAndTranslations() {
         const parsed = JSON.parse(body);
         return parsed.keyUiLocale;
     });
-    const dataElementTranslations = await fetch(
-        "http://localhost:8080/api/dataSets.json?fields=sections[dataElements[id,formName,translations]]&filter=id:eq:jfawDJZ5fOX",
+    const { dataElementTranslations, sectionTranslations } = await fetch(
+        "http://localhost:8080/api/dataSets.json?fields=sections[id,translations,dataElements[id,formName,translations]]&filter=id:eq:jfawDJZ5fOX",
         { method: "GET" }
     ).then(async response => {
         const body = await response.text();
         const parsed = JSON.parse(body);
-        const all = parsed.dataSets[0].sections.reduce((acc, s) => {
+        const allDataElements = parsed.dataSets[0].sections.reduce((acc, s) => {
             return [...acc, s.dataElements];
         }, []);
-        return _.flatten(all);
+
+        const allSections = parsed.dataSets[0].sections.reduce((acc, s) => {
+            return [...acc, { id: s.id, translations: s.translations }];
+        }, []);
+
+        return {
+            dataElementTranslations: _.flatten(allDataElements),
+            sectionTranslations: _.flatten(allSections),
+        };
     });
-    return { dataElementTranslations, userLocale };
+    return { dataElementTranslations, sectionTranslations, userLocale };
 }
 
-function replaceDataElementTitles(dataElementTranslations, userLocale) {
+function replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale) {
+    sectionTranslations.forEach(s => {
+        const translation = s.translations.find(
+            t => t.locale === userLocale && t.property === "NAME"
+        );
+        if (translation) {
+            $(`#${s.id}-section-title`).html(translation.value);
+        }
+    });
     dataElementTranslations.forEach(de => {
         const translation = de.translations.find(
             t => t.locale === userLocale && t.property === "FORM_NAME"

--- a/HEP-data-entry/src/resources/custom-form.js
+++ b/HEP-data-entry/src/resources/custom-form.js
@@ -16,7 +16,7 @@ async function applyChangesToForm() {
 }
 
 async function getLocaleAndTranslations(dataSetId) {
-    const userLocale = await fetch("http://localhost:8080/api/userSettings.json", {
+    const userLocale = await fetch("/api/userSettings.json", {
         method: "GET",
     }).then(async response => {
         const body = await response.text();
@@ -25,7 +25,7 @@ async function getLocaleAndTranslations(dataSetId) {
     });
 
     const { dataElementTranslations, sectionTranslations } = await fetch(
-        `http://localhost:8080/api/dataSets.json?fields=sections[id,translations,dataElements[id,name,formName,translations]]&filter=id:eq:${dataSetId}`,
+        `/api/dataSets.json?fields=sections[id,translations,dataElements[id,name,formName,translations]]&filter=id:eq:${dataSetId}`,
         { method: "GET" }
     ).then(async response => {
         const body = await response.text();

--- a/HEP-data-entry/src/resources/custom-form.js
+++ b/HEP-data-entry/src/resources/custom-form.js
@@ -16,7 +16,7 @@ async function applyChangesToForm() {
 }
 
 async function getLocaleAndTranslations(dataSetId) {
-    const userLocale = await fetch("/api/userSettings.json", {
+    const userLocale = await fetch("../api/userSettings.json", {
         method: "GET",
     }).then(async response => {
         const body = await response.text();
@@ -25,7 +25,7 @@ async function getLocaleAndTranslations(dataSetId) {
     });
 
     const { dataElementTranslations, sectionTranslations } = await fetch(
-        `/api/dataSets.json?fields=sections[id,translations,dataElements[id,name,formName,translations]]&filter=id:eq:${dataSetId}`,
+        `../api/dataSets.json?fields=sections[id,translations,dataElements[id,name,formName,translations]]&filter=id:eq:${dataSetId}`,
         { method: "GET" }
     ).then(async response => {
         const body = await response.text();

--- a/HEP-data-entry/src/resources/custom-form.js
+++ b/HEP-data-entry/src/resources/custom-form.js
@@ -1,4 +1,6 @@
-function applyChangesToForm() {
+async function applyChangesToForm() {
+    const { dataElementTranslations, userLocale } = await getLocaleAndTranslations();
+    await replaceDataElementTitles(dataElementTranslations, userLocale);
     const datasetToApplyChanges = $("#custom-form-script").attr("data-dataset-id");
     const currentDataset = $("#selectedDataSetId").val();
     $("#completenessDiv").wrap("<div id='completenessWrapper'></div>");
@@ -7,6 +9,39 @@ function applyChangesToForm() {
     } else {
         $("#completenessWrapper").show();
     }
+}
+
+async function getLocaleAndTranslations() {
+    const userLocale = await fetch("http://localhost:8080/api/userSettings.json", {
+        method: "GET",
+    }).then(async response => {
+        const body = await response.text();
+        const parsed = JSON.parse(body);
+        return parsed.keyUiLocale;
+    });
+    const dataElementTranslations = await fetch(
+        "http://localhost:8080/api/dataSets.json?fields=sections[dataElements[id,formName,translations]]&filter=id:eq:jfawDJZ5fOX",
+        { method: "GET" }
+    ).then(async response => {
+        const body = await response.text();
+        const parsed = JSON.parse(body);
+        const all = parsed.dataSets[0].sections.reduce((acc, s) => {
+            return [...acc, s.dataElements];
+        }, []);
+        return _.flatten(all);
+    });
+    return { dataElementTranslations, userLocale };
+}
+
+function replaceDataElementTitles(dataElementTranslations, userLocale) {
+    dataElementTranslations.forEach(de => {
+        const translation = de.translations.find(
+            t => t.locale === userLocale && t.property === "FORM_NAME"
+        );
+        if (translation) {
+            $(`#${de.id}-dataElement`).html(translation.value);
+        }
+    });
 }
 
 $(document).on("dhis2.de.event.formLoaded", applyChangesToForm);

--- a/HEP-data-entry/src/resources/custom-form.js
+++ b/HEP-data-entry/src/resources/custom-form.js
@@ -1,10 +1,13 @@
+const GLOBAL_FIELDS_TEMPLATE_SPANISH_HBV = text => `${text} para toda la cascada HBV`;
+const GLOBAL_FIELDS_TEMPLATE_SPANISH_HCV = text => `${text} para toda la cascada HCV`;
+
 async function applyChangesToForm() {
     const {
         dataElementTranslations,
         sectionTranslations,
         userLocale,
     } = await getLocaleAndTranslations();
-    await replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale);
+    replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale);
     const datasetToApplyChanges = $("#custom-form-script").attr("data-dataset-id");
     const currentDataset = $("#selectedDataSetId").val();
     $("#completenessDiv").wrap("<div id='completenessWrapper'></div>");
@@ -24,7 +27,7 @@ async function getLocaleAndTranslations() {
         return parsed.keyUiLocale;
     });
     const { dataElementTranslations, sectionTranslations } = await fetch(
-        "http://localhost:8080/api/dataSets.json?fields=sections[id,translations,dataElements[id,formName,translations]]&filter=id:eq:jfawDJZ5fOX",
+        "http://localhost:8080/api/dataSets.json?fields=sections[id,translations,dataElements[id,name,formName,translations]]&filter=id:eq:jfawDJZ5fOX",
         { method: "GET" }
     ).then(async response => {
         const body = await response.text();
@@ -58,18 +61,30 @@ function replaceLocalizedTexts(dataElementTranslations, sectionTranslations, use
         const translation = de.translations.find(
             t => t.locale === userLocale && t.property === "FORM_NAME"
         );
-        if (translation) {
-            $(`span[id="${de.id}-dataElement"]`).html(translation.value);
-        }
+        if (de.name === "HEP_CASCADE_Additional_Information") {
+            $(`span[id="${de.id}-global-dataElements-0"]`).html(
+                GLOBAL_FIELDS_TEMPLATE_SPANISH_HBV(translation.value)
+            );
+            $(`span[id="${de.id}-global-dataElements-1"]`).html(
+                GLOBAL_FIELDS_TEMPLATE_SPANISH_HCV(translation.value)
+            );
+        } else {
+            const translation = de.translations.find(
+                t => t.locale === userLocale && t.property === "FORM_NAME"
+            );
+            if (translation) {
+                $(`span[id="${de.id}-dataElement"]`).html(translation.value);
+            }
 
-        const descriptionTranslation = de.translations.find(
-            t => t.locale === userLocale && t.property === "DESCRIPTION"
-        );
-        if (descriptionTranslation) {
-            const parsedDescription = JSON.parse(descriptionTranslation.value);
-            $(`i[id="${de.id}-dataElement-description"]`).prop("title", parsedDescription.main);
-            $(`i[id="${de.id}-HBV-field-description"]`).prop("title", parsedDescription.HBV);
-            $(`i[id="${de.id}-HCV-field-description"]`).prop("title", parsedDescription.HCV);
+            const descriptionTranslation = de.translations.find(
+                t => t.locale === userLocale && t.property === "DESCRIPTION"
+            );
+            if (descriptionTranslation) {
+                const parsedDescription = JSON.parse(descriptionTranslation.value);
+                $(`i[id="${de.id}-dataElement-description"]`).prop("title", parsedDescription.main);
+                $(`i[id="${de.id}-HBV-field-description"]`).prop("title", parsedDescription.HBV);
+                $(`i[id="${de.id}-HCV-field-description"]`).prop("title", parsedDescription.HCV);
+            }
         }
     });
 }

--- a/HEP-data-entry/src/resources/custom-form.js
+++ b/HEP-data-entry/src/resources/custom-form.js
@@ -59,7 +59,17 @@ function replaceLocalizedTexts(dataElementTranslations, sectionTranslations, use
             t => t.locale === userLocale && t.property === "FORM_NAME"
         );
         if (translation) {
-            $(`#${de.id}-dataElement`).html(translation.value);
+            $(`span[id="${de.id}-dataElement"]`).html(translation.value);
+        }
+
+        const descriptionTranslation = de.translations.find(
+            t => t.locale === userLocale && t.property === "DESCRIPTION"
+        );
+        if (descriptionTranslation) {
+            const parsedDescription = JSON.parse(descriptionTranslation.value);
+            $(`i[id="${de.id}-dataElement-description"]`).prop("title", parsedDescription.main);
+            $(`i[id="${de.id}-HBV-field-description"]`).prop("title", parsedDescription.HBV);
+            $(`i[id="${de.id}-HCV-field-description"]`).prop("title", parsedDescription.HCV);
         }
     });
 }

--- a/HEP-event-capture/README.md
+++ b/HEP-event-capture/README.md
@@ -12,7 +12,7 @@ $ yarn build
 Example:
 
 ```
-$ node lib/cli.js --url='https://admin:district@play.dhis2.org/2.30' --program-id='kla3mAPgvCH'
+$ node lib/cli.js --url='https://admin:district@play.dhis2.org/2.30' --program-id='cTzRXZGNvqz'
 ```
 
 You can also run code directly from sources using [ts-node](https://www.npmjs.com/package/ts-node):

--- a/HEP-event-capture/src/Dhis2Metadata.ts
+++ b/HEP-event-capture/src/Dhis2Metadata.ts
@@ -30,6 +30,7 @@ export interface ProgramStage {
 }
 
 interface DataElementGroup {
+    id: string;
     code?: string;
     shortName?: string;
     dataElements?: DataElement[];

--- a/HEP-event-capture/src/cli.ts
+++ b/HEP-event-capture/src/cli.ts
@@ -63,7 +63,7 @@ async function getProgramPayload(
 
     const programStage = program.programStages[0];
 
-    const customFormHtml = await AssembledFormHTML({ programStage });
+    const customFormHtml = await AssembledFormHTML({ programStage, programId });
 
     const formId = programStage.dataEntryForm ? programStage.dataEntryForm.id : getUid(program.id);
 

--- a/HEP-event-capture/src/components/AssembledFormHTML.tsx
+++ b/HEP-event-capture/src/components/AssembledFormHTML.tsx
@@ -6,14 +6,23 @@ import { ProgramStage } from "../Dhis2Metadata";
 
 interface AssembledFormHTMLAttributes {
     programStage: ProgramStage;
+    programId: string;
 }
 
 export async function AssembledFormHTML(attributes: AssembledFormHTMLAttributes): Promise<string> {
     const formHtml = Form.getFormHtml(attributes.programStage);
     const style = await getResource("custom-form.css");
+    const javascript = await getResource("custom-form.js");
     return (
         <html>
             <head>
+                <script
+                    id="custom-form-script"
+                    type="text/javascript"
+                    data-program-id={`${attributes.programId}`}
+                >
+                    ${javascript}
+                </script>
                 <style>${style}</style>
                 <link
                     rel="stylesheet"

--- a/HEP-event-capture/src/components/Section.tsx
+++ b/HEP-event-capture/src/components/Section.tsx
@@ -6,7 +6,9 @@ export function Section(attributes: { section: FormSection; i: number }) {
     const { section } = attributes;
     return (
         <div>
-            <div class="section-label">{section.title}</div>
+            <div class="section-label" id={`${section.id}-section-title`}>
+                {section.title}
+            </div>
             <Table dataElements={section.dataElements} programStageId={section.programStageId} />
         </div>
     );

--- a/HEP-event-capture/src/components/Table.tsx
+++ b/HEP-event-capture/src/components/Table.tsx
@@ -8,7 +8,7 @@ function Row(attributes: { dataElement: DataElement; programStageId: string }) {
     const { dataElement, programStageId } = attributes;
 
     //Popup not working -
-    const PopupTitle = <a>{dataElement.formName}</a>;
+    const PopupTitle = <span id={`${dataElement.id}-dataElement`}>{dataElement.formName}</span>;
     const SpanElement = createElement(
         "span",
         {
@@ -28,10 +28,7 @@ function Row(attributes: { dataElement: DataElement; programStageId: string }) {
     const optionListElement = !!dataElement.optionSet;
     return (
         <tr class="ng-scope">
-            <td style="padding:6px;">
-                {SpanElement}
-                <span class="not-for-screen ng-binding">Name of the respondent</span>
-            </td>
+            <td style="padding:6px;">{SpanElement}</td>
             <td>
                 <div
                     class="hideInPrint ng-scope"

--- a/HEP-event-capture/src/components/Table.tsx
+++ b/HEP-event-capture/src/components/Table.tsx
@@ -58,8 +58,8 @@ export function Table(attributes: { dataElements: DataElement[]; programStageId:
         <table class="dhis2-list-table-striped small-vertical-spacing table-width">
             <thead>
                 <tr>
-                    <th class="ng-binding">Data element</th>
-                    <th class="ng-binding">Value</th>
+                    <th class="ng-binding data-element-label">Data element</th>
+                    <th class="ng-binding value-label">Value</th>
                 </tr>
             </thead>
             <tbody>

--- a/HEP-event-capture/src/models/Form.ts
+++ b/HEP-event-capture/src/models/Form.ts
@@ -7,6 +7,7 @@ export interface FormData {
 }
 
 export interface FormSection {
+    id: string;
     title: string;
     dataElements: DataElement[];
     programStageId: string;
@@ -54,6 +55,7 @@ export class Form {
             const order = orderAttribute && orderAttribute.value;
 
             return {
+                id: deg.id,
                 title: deg.shortName,
                 programStageId: programStage.id,
                 order,

--- a/HEP-event-capture/src/resources/custom-form.js
+++ b/HEP-event-capture/src/resources/custom-form.js
@@ -9,7 +9,7 @@ async function applyChangesToForm() {
 }
 
 async function getLocaleAndTranslations(programId) {
-    const userLocale = await fetch("http://localhost:8080/api/userSettings.json", {
+    const userLocale = await fetch("/api/userSettings.json", {
         method: "GET",
     }).then(async response => {
         const body = await response.text();
@@ -17,7 +17,7 @@ async function getLocaleAndTranslations(programId) {
         return parsed.keyUiLocale;
     });
     const { dataElementTranslations, sectionTranslations } = await fetch(
-        `http://localhost:8080/api/programs.json?fields=programStages[programStageDataElements[dataElement[dataElementGroups[id,code,shortName,translations,dataElements[id,translations]]]]]&filter=id:eq:${programId}`,
+        `/api/programs.json?fields=programStages[programStageDataElements[dataElement[dataElementGroups[id,code,shortName,translations,dataElements[id,translations]]]]]&filter=id:eq:${programId}`,
         { method: "GET" }
     ).then(async response => {
         const body = await response.text();

--- a/HEP-event-capture/src/resources/custom-form.js
+++ b/HEP-event-capture/src/resources/custom-form.js
@@ -1,0 +1,81 @@
+async function applyChangesToForm() {
+    const {
+        dataElementTranslations,
+        sectionTranslations,
+        userLocale,
+    } = await getLocaleAndTranslations();
+    replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale);
+}
+
+async function getLocaleAndTranslations() {
+    const userLocale = await fetch("http://localhost:8080/api/userSettings.json", {
+        method: "GET",
+    }).then(async response => {
+        const body = await response.text();
+        const parsed = JSON.parse(body);
+        return parsed.keyUiLocale;
+    });
+    const { dataElementTranslations, sectionTranslations } = await fetch(
+        "http://localhost:8080/api/programs.json?fields=programStages[programStageDataElements[dataElement[dataElementGroups[id,code,shortName,translations,dataElements[id,translations]]]]]&filter=id:eq:cTzRXZGNvqz",
+        { method: "GET" }
+    ).then(async response => {
+        const body = await response.text();
+        const parsed = JSON.parse(body);
+        const programStageDataElements =
+            parsed.programs[0].programStages[0].programStageDataElements;
+        const dataElementGroups = getDataElementGroups(programStageDataElements);
+        const allDataElements = dataElementGroups.reduce((acc, s) => {
+            return [...acc, s.dataElements];
+        }, []);
+
+        const allSections = dataElementGroups.reduce((acc, s) => {
+            return [...acc, { id: s.id, translations: s.translations }];
+        }, []);
+
+        return {
+            dataElementTranslations: _.flatten(allDataElements),
+            sectionTranslations: _.flatten(allSections),
+        };
+    });
+    return { dataElementTranslations, sectionTranslations, userLocale };
+}
+
+function getDataElementGroups(programStageDataElements) {
+    const formCodes = {
+        formSection: "HEP_POLICY_SECTION",
+        sectionOrder: "SECTION_ORDER",
+        formDataElementGroup: "HEP_POLICY_EVENT_CAPTURE",
+        optionList: "USE_OPTION_FIELD",
+    };
+    const allDataElementGroups = programStageDataElements.map(
+        psde =>
+            psde.dataElement.dataElementGroups &&
+            psde.dataElement.dataElementGroups.find(
+                deg => deg.code && deg.code.startsWith(formCodes.formSection)
+            )
+    );
+    const dataElementGroups = _.uniqBy(_.compact(allDataElementGroups), "code");
+    return dataElementGroups;
+}
+
+function replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale) {
+    sectionTranslations.forEach(s => {
+        const translation = s.translations.find(
+            t => t.locale === userLocale && t.property === "SHORT_NAME"
+        );
+        if (translation) {
+            $(`#${s.id}-section-title`).html(translation.value);
+        }
+    });
+
+    dataElementTranslations.forEach(de => {
+        const translation = de.translations.find(
+            t => t.locale === userLocale && t.property === "FORM_NAME"
+        );
+        if (translation) {
+            $(`span[id="${de.id}-dataElement"]`).html(translation.value);
+        }
+    });
+}
+
+applyChangesToForm();

--- a/HEP-event-capture/src/resources/custom-form.js
+++ b/HEP-event-capture/src/resources/custom-form.js
@@ -1,13 +1,14 @@
 async function applyChangesToForm() {
+    const programToApplyChanges = $("#custom-form-script").attr("data-program-id");
     const {
         dataElementTranslations,
         sectionTranslations,
         userLocale,
-    } = await getLocaleAndTranslations();
+    } = await getLocaleAndTranslations(programToApplyChanges);
     replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale);
 }
 
-async function getLocaleAndTranslations() {
+async function getLocaleAndTranslations(programId) {
     const userLocale = await fetch("http://localhost:8080/api/userSettings.json", {
         method: "GET",
     }).then(async response => {
@@ -16,7 +17,7 @@ async function getLocaleAndTranslations() {
         return parsed.keyUiLocale;
     });
     const { dataElementTranslations, sectionTranslations } = await fetch(
-        "http://localhost:8080/api/programs.json?fields=programStages[programStageDataElements[dataElement[dataElementGroups[id,code,shortName,translations,dataElements[id,translations]]]]]&filter=id:eq:cTzRXZGNvqz",
+        `http://localhost:8080/api/programs.json?fields=programStages[programStageDataElements[dataElement[dataElementGroups[id,code,shortName,translations,dataElements[id,translations]]]]]&filter=id:eq:${programId}`,
         { method: "GET" }
     ).then(async response => {
         const body = await response.text();

--- a/HEP-event-capture/src/resources/custom-form.js
+++ b/HEP-event-capture/src/resources/custom-form.js
@@ -9,7 +9,7 @@ async function applyChangesToForm() {
 }
 
 async function getLocaleAndTranslations(programId) {
-    const userLocale = await fetch("/api/userSettings.json", {
+    const userLocale = await fetch("../api/userSettings.json", {
         method: "GET",
     }).then(async response => {
         const body = await response.text();
@@ -17,7 +17,7 @@ async function getLocaleAndTranslations(programId) {
         return parsed.keyUiLocale;
     });
     const { dataElementTranslations, sectionTranslations } = await fetch(
-        `/api/programs.json?fields=programStages[programStageDataElements[dataElement[dataElementGroups[id,code,shortName,translations,dataElements[id,translations]]]]]&filter=id:eq:${programId}`,
+        `../api/programs.json?fields=programStages[programStageDataElements[dataElement[dataElementGroups[id,code,shortName,translations,dataElements[id,translations]]]]]&filter=id:eq:${programId}`,
         { method: "GET" }
     ).then(async response => {
         const body = await response.text();

--- a/HEP-event-capture/src/resources/custom-form.js
+++ b/HEP-event-capture/src/resources/custom-form.js
@@ -59,6 +59,17 @@ function getDataElementGroups(programStageDataElements) {
 }
 
 function replaceLocalizedTexts(dataElementTranslations, sectionTranslations, userLocale) {
+    const tableLabels = {
+        fr: {
+            dataElement: "Élément de données",
+            value: "Valeur",
+        },
+        es: {
+            dataElement: "Elemento de datos",
+            value: "Valor",
+        },
+    };
+
     sectionTranslations.forEach(s => {
         const translation = s.translations.find(
             t => t.locale === userLocale && t.property === "SHORT_NAME"
@@ -67,6 +78,11 @@ function replaceLocalizedTexts(dataElementTranslations, sectionTranslations, use
             $(`#${s.id}-section-title`).html(translation.value);
         }
     });
+
+    if (tableLabels[userLocale]) {
+        $(".data-element-label").html(tableLabels[userLocale].dataElement);
+        $(".value-label").html(tableLabels[userLocale].value);
+    }
 
     dataElementTranslations.forEach(de => {
         const translation = de.translations.find(


### PR DESCRIPTION
Currently working for Spanish and French.
There are some special cases like section headers or the global textFields in the dataEntry form which currently have to be hardcoded into the script when adding a new locale to support. 