### PR TITLE
Feature/changes in customform module 1 subnational single entry

### DIFF
--- a/HEP-data-entry/src/components/module1_subnational_single/CustomForm.tsx
+++ b/HEP-data-entry/src/components/module1_subnational_single/CustomForm.tsx
@@ -13,7 +13,8 @@ export default async function CustomForm(dataSet: DataSet): Promise<string> {
     }
 
     const style = await getResource("custom-form.css");
-    const javascript = await getResource("custom-form.js");
+    const customFormJs = await getResource("custom-form.js");
+    const sheetseeJs = await getResource("sheetsee.js");
 
     console.log(dataSet.id);
 
@@ -21,53 +22,91 @@ export default async function CustomForm(dataSet: DataSet): Promise<string> {
         <div>
             <style>{style}</style>
             <script src="https://unpkg.com/mustache@4.0.1"></script>
-            <script id="template" type="x-tmpl-mustache">
-                <tr>
-                    <th>Total</th>
-                    <th class="simple-de">{"{{orgUnitName}}"}</th>
+            <script id="orgUnitsTable_template" type="x-tmpl-mustache">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>SN</th>
 
-                    <td class="td-input">
-                        <input id={`{{orgUnitId}}-${correctOrgUnitNameDE.id}`} type="text" />
-                    </td>
+                            <th></th>
+                            <th></th>
 
-                    {dataElementGroups.map(group => {
-                        const id = `{{orgUnitId}}-${group.inputNumeric.id}`;
-                        const className = group.readOnly ? "td-input read-only" : "td-input";
+                            {dataElementGroups.map(group => {
+                                return <th>{group.order}</th>;
+                            })}
+                            <th></th>
+                        </tr>
+                        <tr>
+                            <th>Occupation</th>
 
-                        return (
-                            <td class={className}>
-                                <input id={id} type="text" />
-                            </td>
-                        );
-                    })}
+                            <th class="simple-de">Subnational level name</th>
 
-                    <td class="td-input">
-                        <textarea id={`{{orgUnitId}}-${commentDE.id}`} />
-                    </td>
-                </tr>
-                <tr>
-                    <th>Source Type</th>
-                    <th></th>
-                    <th></th>
+                            <th class="simple-de">{correctOrgUnitNameDE.displayName}</th>
 
-                    {dataElementGroups.map((group, index) => {
-                        const containerId = `{{orgUnitId}}-checkboxes${index}`;
-                        const className = group.readOnly ? "read-only" : "";
+                            {dataElementGroups.map(group => {
+                                return <th class="numeric-de">{group.inputNumeric.displayName}</th>;
+                            })}
 
-                        return (
-                            <td class={className}>
-                                <TrueOnlyEntries
-                                    containerId={containerId}
-                                    inputCheckboxes={group.inputCheckboxes}
+                            <th class="simple-de">{commentDE.displayName}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {"{{#rows}}"}
+                        <tr>
+                            <th>Total</th>
+                            <th class="simple-de">{"{{orgUnitName}}"}</th>
+
+                            <td class="td-input">
+                                <input
+                                    id={`{{orgUnitId}}-${correctOrgUnitNameDE.id}`}
+                                    type="text"
                                 />
                             </td>
-                        );
-                    })}
 
-                    <td></td>
-                </tr>
+                            {dataElementGroups.map(group => {
+                                const id = `{{orgUnitId}}-${group.inputNumeric.id}`;
+                                const className = group.readOnly
+                                    ? "td-input read-only"
+                                    : "td-input";
+
+                                return (
+                                    <td class={className}>
+                                        <input id={id} type="text" />
+                                    </td>
+                                );
+                            })}
+
+                            <td class="td-input">
+                                <textarea id={`{{orgUnitId}}-${commentDE.id}`} />
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Source Type</th>
+                            <th></th>
+                            <th></th>
+
+                            {dataElementGroups.map((group, index) => {
+                                const containerId = `{{orgUnitId}}-checkboxes${index}`;
+                                const className = group.readOnly ? "read-only" : "";
+
+                                return (
+                                    <td class={className}>
+                                        <TrueOnlyEntries
+                                            containerId={containerId}
+                                            inputCheckboxes={group.inputCheckboxes}
+                                        />
+                                    </td>
+                                );
+                            })}
+
+                            <td></td>
+                        </tr>
+                        {"{{/rows}}"}
+                    </tbody>
+                </table>
             </script>
-            <script>{javascript}</script>
+            <script>{sheetseeJs}</script>
+            <script>{customFormJs}</script>
             <h3 style="text-align: center;">
                 <strong>Active Health Workforce Demographic Details</strong>
             </h3>
@@ -100,41 +139,7 @@ export default async function CustomForm(dataSet: DataSet): Promise<string> {
                 <div id="tab0">
                     <h2>SECTION 1: HWF WORKING DETAILS</h2>
 
-                    <div class="cde">
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>SN</th>
-
-                                    <th></th>
-                                    <th></th>
-
-                                    {dataElementGroups.map(group => {
-                                        return <th>{group.order}</th>;
-                                    })}
-                                    <th></th>
-                                </tr>
-                                <tr>
-                                    <th>Occupation</th>
-
-                                    <th class="simple-de">Subnational level name</th>
-
-                                    <th class="simple-de">{correctOrgUnitNameDE.displayName}</th>
-
-                                    {dataElementGroups.map(group => {
-                                        return (
-                                            <th class="numeric-de">
-                                                {group.inputNumeric.displayName}
-                                            </th>
-                                        );
-                                    })}
-
-                                    <th class="simple-de">{commentDE.displayName}</th>
-                                </tr>
-                            </thead>
-                            <tbody></tbody>
-                        </table>
-                    </div>
+                    <div id="orgUnitsTable" class="cde"></div>
                     <div id="custom-form-loader">
                         <img id="loader" src="../images/ajax-loader-circle.gif" />
 

--- a/HEP-data-entry/src/components/module1_subnational_single/CustomForm.tsx
+++ b/HEP-data-entry/src/components/module1_subnational_single/CustomForm.tsx
@@ -1,6 +1,6 @@
 import { createElement } from "typed-html";
 import { DataSet } from "../../models/Dhis2Metadata";
-import { dataElementGroups, simpleDataElements } from "./dataElementGroups";
+import { commentDE, correctOrgUnitNameDE, dataElementGroups } from "./dataElementGroups";
 import { TrueOnlyEntries } from "./TrueOnlyEntries";
 import { getResource } from "./utils";
 
@@ -17,92 +17,55 @@ export default async function CustomForm(dataSet: DataSet): Promise<string> {
 
     console.log(dataSet.id);
 
-    const nameToken = "{{orgUnitName}}";
-
     const html = (
         <div>
             <style>{style}</style>
             <script src="https://unpkg.com/mustache@4.0.1"></script>
             <script id="template" type="x-tmpl-mustache">
-                <div class="cde">
-                    <h3> {nameToken}</h3>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <th>SN</th>
+                <tr>
+                    <th>Total</th>
+                    <th class="simple-de">{"{{orgUnitName}}"}</th>
 
-                                {dataElementGroups.map(group => {
-                                    return <th>{group.order}</th>;
-                                })}
+                    <td class="td-input">
+                        <input id={`{{orgUnitId}}-${correctOrgUnitNameDE.id}`} type="text" />
+                    </td>
 
-                                {simpleDataElements.map(() => {
-                                    return <th></th>;
-                                })}
-                            </tr>
-                            <tr>
-                                <th>Occupation</th>
+                    {dataElementGroups.map(group => {
+                        const id = `{{orgUnitId}}-${group.inputNumeric.id}`;
+                        const className = group.readOnly ? "td-input read-only" : "td-input";
 
-                                {dataElementGroups.map(group => {
-                                    return (
-                                        <th class="numeric-de">{group.inputNumeric.displayName}</th>
-                                    );
-                                })}
+                        return (
+                            <td class={className}>
+                                <input id={id} type="text" />
+                            </td>
+                        );
+                    })}
 
-                                {simpleDataElements.map(de => {
-                                    return <th class="simple-de">{de.displayName}</th>;
-                                })}
-                            </tr>
-                            <tr>
-                                <th>Total</th>
-                                {dataElementGroups.map(group => {
-                                    const id = `{{orgUnitId}}-${group.inputNumeric.id}`;
-                                    const className = group.readOnly
-                                        ? "td-input read-only"
-                                        : "td-input";
+                    <td class="td-input">
+                        <textarea id={`{{orgUnitId}}-${commentDE.id}`} />
+                    </td>
+                </tr>
+                <tr>
+                    <th>Source Type</th>
+                    <th></th>
+                    <th></th>
 
-                                    return (
-                                        <td class={className}>
-                                            <input id={id} type="text" />
-                                        </td>
-                                    );
-                                })}
+                    {dataElementGroups.map((group, index) => {
+                        const containerId = `{{orgUnitId}}-checkboxes${index}`;
+                        const className = group.readOnly ? "read-only" : "";
 
-                                {simpleDataElements.map(de => {
-                                    const id = `{{orgUnitId}}-${de.id}`;
-                                    const tdContent =
-                                        de.type === "text-area" ? (
-                                            <textarea id={id} />
-                                        ) : (
-                                            <input id={id} type="text" />
-                                        );
+                        return (
+                            <td class={className}>
+                                <TrueOnlyEntries
+                                    containerId={containerId}
+                                    inputCheckboxes={group.inputCheckboxes}
+                                />
+                            </td>
+                        );
+                    })}
 
-                                    return <td class="td-input">{tdContent}</td>;
-                                })}
-                            </tr>
-                            <tr>
-                                <th>Source Type</th>
-
-                                {dataElementGroups.map((group, index) => {
-                                    const containerId = `{{orgUnitId}}-checkboxes${index}`;
-                                    const className = group.readOnly ? "read-only" : "";
-
-                                    return (
-                                        <td class={className}>
-                                            <TrueOnlyEntries
-                                                containerId={containerId}
-                                                inputCheckboxes={group.inputCheckboxes}
-                                            />
-                                        </td>
-                                    );
-                                })}
-
-                                {simpleDataElements.map(() => {
-                                    return <td></td>;
-                                })}
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
+                    <td></td>
+                </tr>
             </script>
             <script>{javascript}</script>
             <h3 style="text-align: center;">
@@ -137,7 +100,41 @@ export default async function CustomForm(dataSet: DataSet): Promise<string> {
                 <div id="tab0">
                     <h2>SECTION 1: HWF WORKING DETAILS</h2>
 
-                    <div id="content"></div>
+                    <div class="cde">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>SN</th>
+
+                                    <th></th>
+                                    <th></th>
+
+                                    {dataElementGroups.map(group => {
+                                        return <th>{group.order}</th>;
+                                    })}
+                                    <th></th>
+                                </tr>
+                                <tr>
+                                    <th>Occupation</th>
+
+                                    <th class="simple-de">Subnational level name</th>
+
+                                    <th class="simple-de">{correctOrgUnitNameDE.displayName}</th>
+
+                                    {dataElementGroups.map(group => {
+                                        return (
+                                            <th class="numeric-de">
+                                                {group.inputNumeric.displayName}
+                                            </th>
+                                        );
+                                    })}
+
+                                    <th class="simple-de">{commentDE.displayName}</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
                     <div id="custom-form-loader">
                         <img id="loader" src="../images/ajax-loader-circle.gif" />
 
@@ -160,7 +157,7 @@ function getMissingDataElementsInDataSet(dataSet: DataSet) {
     const checkboxesInputs = dataElementGroups.flatMap(de =>
         de.inputCheckboxes.map(de => de.id.split("-")[0])
     );
-    const textInputs = simpleDataElements.map(de => de.id.split("-")[0]);
+    const textInputs = [correctOrgUnitNameDE.id.split("-")[0], commentDE.id.split("-")[0]];
 
     const allDEInForm = [...numericInputs, ...new Set(checkboxesInputs), ...textInputs].sort();
 

--- a/HEP-data-entry/src/components/module1_subnational_single/dataElementGroups.ts
+++ b/HEP-data-entry/src/components/module1_subnational_single/dataElementGroups.ts
@@ -3556,16 +3556,15 @@ export const dataElementGroups: DataElementGroup[] = [
     }
 ]
 
+export const correctOrgUnitNameDE = {
+    id: 'ZUCnSGgjlrw-Xr12mI7VPn3-val',
+    displayName: 'Correct organisation unit name',
+    type: "text"
+};
 
-export const simpleDataElements: CustomDataElement[] = [
-    {
-        id: 'ZUCnSGgjlrw-Xr12mI7VPn3-val',
-        displayName: 'Correct organisation unit name',
-        type: "text"
-    },
-    {
-        id: 'kiwzlhjDZG9-Xr12mI7VPn3-val',
-        displayName: 'If you have data on occupations and their source title, that are not listed above please provide below',
-        type: "text-area"
-    }
-]
+export const commentDE = {
+    id: 'kiwzlhjDZG9-Xr12mI7VPn3-val',
+    displayName: 'If you have data on occupations and their source title, that are not listed above please provide below',
+    type: "text-area"
+};
+

--- a/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.css
+++ b/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.css
@@ -95,9 +95,37 @@ textarea {
 #custom-form-loader {
     color: #1c425c;
     font-size: 14px;
-    border: 1px solid #9aaab5;
     margin: 20px;
     text-align: center;
     display: none;
     border-radius: 3px;
+}
+
+.cde table thead tr:nth-child(1) th {
+    position: sticky;
+    position: -webkit-sticky;
+    top: 48px;
+    background: #f5f5f5;
+    z-index: 50;
+}
+
+.cde table thead tr:nth-child(2) th {
+    position: sticky;
+    position: -webkit-sticky;
+    top: 99px;
+    background: #f5f5f5;
+    z-index: 50;
+}
+
+#leftBar {
+    z-index: 100;
+}
+
+tr {
+    background: #f5f5f5;
+}
+
+tr:nth-child(4n + 1),
+tr:nth-child(4n + 2) {
+    background: white;
 }

--- a/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.css
+++ b/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.css
@@ -129,3 +129,41 @@ tr:nth-child(4n + 1),
 tr:nth-child(4n + 2) {
     background: white;
 }
+
+#Pagination {
+    margin-top: 16px;
+    font-size: 14px;
+}
+
+.pagination-next-orgUnitsTable:hover,
+.pagination-pre-orgUnitsTable:hover {
+    background: black;
+    color: white;
+    text-decoration: none;
+}
+
+.pagination-next-orgUnitsTable,
+.pagination-pre-orgUnitsTable {
+    box-sizing: border-box;
+    display: inline-block;
+    text-align: center;
+    padding: 4px;
+    text-decoration: none;
+    cursor: pointer;
+    color: #333;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    text-decoration: none;
+}
+.no-pag {
+    cursor: default;
+    color: #666 !important;
+    border: 1px solid transparent;
+    background: transparent;
+    box-shadow: none;
+    cursor: default;
+}
+
+.no-pag:hover {
+    background: transparent;
+}

--- a/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.js
+++ b/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.js
@@ -513,26 +513,27 @@ function loadValues() {
 }
 
 function renderCustomForm() {
-    $("#content").empty();
+    $(".cde table tbody").empty();
     $("#custom-form-loader").show();
 
-    const filter = `var=dataSet:${module1SubnationalId}&var=orgUnit:${dhis2.de.currentOrganisationUnitId}`;
+    const filter = `paging=false&var=dataSet:${module1SubnationalId}&var=orgUnit:${dhis2.de.currentOrganisationUnitId}`;
 
     $.ajax({
         url: `../api/sqlViews/F9WNm3XNjli/data?${filter}`,
         type: "get",
         success: function(response) {
-            const orgUnits = response.listGrid.rows.map(row => ({
+            const orgUnits = response.listGrid.rows.map((row, index) => ({
                 orgUnitId: row[0],
                 orgUnitName: row[1],
+                showHeaders: index === 0,
             }));
 
-            const orgUnitTables = orgUnits.map(orgUnit => {
+            const rows = orgUnits.map(orgUnit => {
                 var template = document.getElementById("template").innerHTML;
                 return Mustache.render(template, orgUnit);
             });
 
-            document.getElementById("content").innerHTML = orgUnitTables.join();
+            $(".cde table tbody").html(rows.join(""));
 
             $(".read-only input").each(function() {
                 $(this).attr("disabled", "disabled");

--- a/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.js
+++ b/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.js
@@ -516,16 +516,15 @@ function renderCustomForm() {
     $("#content").empty();
     $("#custom-form-loader").show();
 
-    const fields = `fields=id,shortName`;
-    const filter = `filter=dataSets.id:eq:${module1SubnationalId}&filter=path:like:${dhis2.de.currentOrganisationUnitId}`;
+    const filter = `var=dataSet:${module1SubnationalId}&var=orgUnit:${dhis2.de.currentOrganisationUnitId}`;
 
     $.ajax({
-        url: `../api/organisationUnits?${fields}&${filter}`,
+        url: `../api/sqlViews/F9WNm3XNjli/data?${filter}`,
         type: "get",
         success: function(response) {
-            const orgUnits = response.organisationUnits.map(ou => ({
-                orgUnitId: ou.id,
-                orgUnitName: ou.shortName,
+            const orgUnits = response.listGrid.rows.map(row => ({
+                orgUnitId: row[0],
+                orgUnitName: row[1],
             }));
 
             const orgUnitTables = orgUnits.map(orgUnit => {

--- a/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.js
+++ b/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.js
@@ -469,6 +469,22 @@ function showCheckboxes(element) {
 }
 
 function loadValues() {
+    $(".read-only input").each(function() {
+        $(this).attr("disabled", "disabled");
+    });
+
+    document.querySelector(".pagination-next-orgUnitsTable").addEventListener("click", function(e) {
+        if (e.target.classList.contains("no-pag")) return;
+
+        loadValues();
+    });
+
+    document.querySelector(".pagination-pre-orgUnitsTable").addEventListener("click", function(e) {
+        if (e.target.classList.contains("no-pag")) return;
+
+        loadValues();
+    });
+
     var periodId = $("#selectedPeriodId").val();
 
     var params = {
@@ -522,22 +538,19 @@ function renderCustomForm() {
         url: `../api/sqlViews/F9WNm3XNjli/data?${filter}`,
         type: "get",
         success: function(response) {
-            const orgUnits = response.listGrid.rows.map((row, index) => ({
+            const orgUnits = response.listGrid.rows.map(row => ({
                 orgUnitId: row[0],
                 orgUnitName: row[1],
-                showHeaders: index === 0,
             }));
 
-            const rows = orgUnits.map(orgUnit => {
-                var template = document.getElementById("template").innerHTML;
-                return Mustache.render(template, orgUnit);
-            });
+            var tableOptions = {
+                data: orgUnits,
+                pagination: 10,
+                tableDiv: "#orgUnitsTable",
+                templateID: "orgUnitsTable_template",
+            };
 
-            $(".cde table tbody").html(rows.join(""));
-
-            $(".read-only input").each(function() {
-                $(this).attr("disabled", "disabled");
-            });
+            makeTable(tableOptions);
 
             $("#custom-form-loader").hide();
 

--- a/HEP-data-entry/src/components/module1_subnational_single/resources/sheetsee.js
+++ b/HEP-data-entry/src/components/module1_subnational_single/resources/sheetsee.js
@@ -1,0 +1,207 @@
+// **** sheetsee-tables ****
+// https://github.com/jlord/sheetsee-tables/blob/master/index.js
+// I have not found a cdn to download by scrript link
+// I try https://cdn.rawgit.com/jlord/sheetsee.js/master/js/sheetsee.js but fail sometimes
+var tblOpts = {};
+
+// Only called the very first time
+function makeTable(data) {
+    tblOpts = data;
+    tblOpts.sortMeta = {};
+    tblOpts.pgnMta = {};
+
+    if (!tblOpts.templateID) {
+        tblOpts.templateID = tblOpts.tableDiv.replace("#", "") + "_template";
+    }
+
+    buildPaginationMeta(data.data, data.pagination);
+
+    prepTable();
+    initiateTableSorter();
+}
+
+// SORTING
+
+// Called once to listen for clicks on table headers
+function initiateTableSorter() {
+    document.body.addEventListener("click", function(event) {
+        if (event.target.classList.contains("tHeader")) {
+            perpareSort(event);
+        }
+    });
+}
+
+// Prepare to be sorted
+function perpareSort(event) {
+    if (!tblOpts.sortMeta.sorted || tblOpts.sortMeta.sorted === "descending") {
+        tblOpts.sortMeta.sorted = "ascending";
+    } else if (tblOpts.sortMeta.sorted === "ascending") tblOpts.sortMeta.sorted = "descending";
+    // TODO maybe make all keys in data lowercase...
+    tblOpts.sortMeta.sortBy = event.target.innerHTML.replace(/\s/g, "").replace(/\W/g, "");
+    tblOpts.tableDiv = "#" + event.target.closest("div").getAttribute("id");
+    sortData();
+}
+
+// Sort the data
+function sortData() {
+    var sortGroup;
+    if (tblOpts.filtering) sortGroup = tblOpts.pgnMta.allRows;
+    else sortGroup = tblOpts.data;
+
+    sortGroup.sort(function(a, b) {
+        var aa = a[tblOpts.sortMeta.sortBy].toLowerCase();
+        var bb = b[tblOpts.sortMeta.sortBy].toLowerCase();
+        aa = aa.match(/^[\d,]$/) ? Number(aa) : aa;
+        bb = bb.match(/^[\d,]$/) ? Number(bb) : bb;
+
+        if (aa < bb) return -1;
+        if (aa > bb) return 1;
+        return 0;
+    });
+    if (tblOpts.sortMeta.sorted === "descending") sortGroup.reverse();
+    // This table update doesn't change pagination; reset direction
+    if (tblOpts.pgnMta.dir) tblOpts.pgnMta.dir = Number(0);
+    // If the table has been filtered, just sort those
+    if (tblOpts.filtering) prepTable(tblOpts.pgnMta.allRows);
+    else prepTable();
+}
+
+// FITERING
+
+// Set up listeners for clear and input
+function initiateTableFilter(options) {
+    // If things are missing, return
+    if (document.querySelector(".clear") === null) return;
+    if (!options.filterDiv) return;
+    if (document.getElementById(options.filterDiv.replace("#", "")) === null) return;
+
+    tblOpts.filtering = true;
+    var filterInput = document.getElementById(options.filterDiv.replace("#", ""));
+
+    // listen for clicks on clear button
+    document.querySelector(".clear").addEventListener("click", function() {
+        filterInput.value = "";
+        // This resets the table to initial direction
+        if (tblOpts.pgnMta.dir) tblOpts.pgnMta.dir = Number(0);
+        // TODO should it reset to page 1
+        prepTable();
+    });
+    // Listen for input in the serach field
+    filterInput.addEventListener("keyup", function(e) {
+        searchTable(e.target.value);
+    });
+}
+
+// Search the table with input
+function searchTable(searchTerm) {
+    var filteredList = [];
+    tblOpts.data.forEach(function(object) {
+        var stringObject = JSON.stringify(object).toLowerCase();
+        if (stringObject.match(searchTerm.toLowerCase())) filteredList.push(object);
+    });
+    // Clear direction and page
+    if (tblOpts.pgnMta.dir) tblOpts.pgnMta.dir = Number(0);
+    if (tblOpts.pgnMta.crntPage) tblOpts.pgnMta.crntPage = Number(1);
+    prepTable(filteredList);
+}
+
+// TABLE MAKING
+
+// Prep the data and pagination for the table
+function prepTable(filteredList) {
+    var data = filteredList || tblOpts.data;
+
+    // If they don't specifiy pagination, draw table with everything
+    if (!tblOpts.pagination) return updateTable(data);
+
+    // Create Pagination Metadata
+    buildPaginationMeta(data);
+    // Build the table with paginated data
+    updateTable(tblOpts.pgnMta.crntRows);
+    // Append pagination DOM elements
+    // If there is no data, don't paginate
+    if (data.length === 0) addPaginationDOM(true);
+    else addPaginationDOM();
+}
+
+function updateTable(data) {
+    var rawTemplate = document.getElementById(tblOpts.templateID).innerHTML;
+    var content = Mustache.render(rawTemplate, { rows: data });
+    document.getElementById(tblOpts.tableDiv.replace("#", "")).innerHTML = content;
+}
+
+// PAGINATION
+
+// Create the metadata used in pagination
+function buildPaginationMeta(data) {
+    var dir = tblOpts.pgnMta.dir || 0;
+    var current = tblOpts.pgnMta.crntPage || 1;
+    tblOpts.pgnMta.allRows = data;
+    tblOpts.pgnMta.allRowsLen = data.length;
+    tblOpts.pgnMta.totalPages = Math.ceil(tblOpts.pgnMta.allRowsLen / tblOpts.pagination);
+    tblOpts.pgnMta.crntPage = current + dir;
+    tblOpts.pgnMta.nextPage = tblOpts.pgnMta.crntPage - 1;
+    tblOpts.pgnMta.crntStart = tblOpts.pgnMta.crntPage * tblOpts.pagination - tblOpts.pagination;
+    tblOpts.pgnMta.crntEnd = tblOpts.pgnMta.crntPage * tblOpts.pagination;
+    tblOpts.pgnMta.crntRows = data.slice(tblOpts.pgnMta.crntStart, tblOpts.pgnMta.crntEnd);
+    return;
+}
+
+// Add pagination elements and listeners to the DOM
+function addPaginationDOM(nopages) {
+    var tblId = tblOpts.tableDiv.slice(1);
+    var el = document.createElement("div");
+    el.setAttribute("id", "Pagination");
+    el.setAttribute("pageno", tblOpts.pgnMta.crntPage);
+    el.classList.add("table-pagination");
+    if (nopages) {
+        el.innerHTML = "No results</div>";
+    } else if (tblOpts.pgnMta.allRowsLen <= tblOpts.pagination) {
+        el.innerHTML = "Page 1 of 1</div>";
+    } else {
+        el.innerHTML =
+            "Showing page " +
+            tblOpts.pgnMta.crntPage +
+            " of " +
+            tblOpts.pgnMta.totalPages +
+            " <a class='pagination-pre-" +
+            tblId +
+            "'>Previous</a>" +
+            " <a class='pagination-next-" +
+            tblId +
+            "'>Next</a></div>";
+    }
+    document.getElementById(tblId).append(el);
+    // Don't show pagination in these cases TODO clean up
+    if (nopages) return;
+    if (tblOpts.pgnMta.allRowsLen <= tblOpts.pagination) return;
+
+    // On the last page
+    if (tblOpts.pgnMta.crntPage >= tblOpts.pgnMta.totalPages) {
+        document.querySelector(".pagination-next-" + tblId).classList.add("no-pag");
+        document.querySelector(".pagination-pre-" + tblId).classList.remove("no-pag");
+    }
+    // On the first page
+    if (tblOpts.pgnMta.crntPage === 1) {
+        document.querySelector(".pagination-pre-" + tblId).classList.add("no-pag");
+        document.querySelector(".pagination-next-" + tblId).classList.remove("no-pag");
+    }
+    // Listen for next clicks
+    document.querySelector(".pagination-next-" + tblId).addEventListener("click", function(e) {
+        if (e.target.classList.contains("no-pag")) return;
+        tblOpts.pgnMta.dir = Number(1);
+        // if there is text in the search and you are paginating
+        // through filtered data, build table with what is in paginationmeta data
+        if (tblOpts.filtering) prepTable(tblOpts.pgnMta.allRows);
+        else prepTable();
+    });
+    // Listen for previous clicks
+    document.querySelector(".pagination-pre-" + tblId).addEventListener("click", function(e) {
+        if (e.target.classList.contains("no-pag")) return;
+        tblOpts.pgnMta.dir = Number(-1);
+        // if there is text in the search and you are paginating
+        // through filtered data, build table with what is in paginationmeta data
+        if (tblOpts.filtering) prepTable(tblOpts.pgnMta.allRows);
+        else prepTable();
+    });
+}


### PR DESCRIPTION
### :pushpin: References

closes #36 

### :memo: Implementation

- [x] Custom form performance
- [x] Show org unit name y correct org unit name as column 2 y 3 (Subnational level name, corrected subnational OU name)
- [x] Show to visual level one table (in HTML maintain a table per org unit)
- [x] Fixed headers to scroll
- [x] Add Pagination

### :art: Screenshots

<img width="1409" alt="Captura de pantalla 2020-11-19 a las 10 50 58" src="https://user-images.githubusercontent.com/5593590/99650068-413c7500-2a55-11eb-9d7a-fcf284ed64ca.png">


### :fire: Is there anything the reviewer should know to test it?

It's necessary the metadata generated in the last PR #30
[metadata.json.zip](https://github.com/EyeSeeTea/WHO-custom-forms/files/5382543/metadata.json.zip)

- New data set Module 1 (subnational single entry)
- New data element to fix org unit name and it's added to Module 1 (subnational) and Module 1 (subnational single entry)

[Module 1 (subnational single entry)-sqlview.json.zip](https://github.com/EyeSeeTea/WHO-custom-forms/files/5565374/Module.1.subnational.single.entry.-sqlview.json.zip)

Contain the sql view to retrieve org unit children for the custom form. It's not necessary execute the sqlview because is a query type sql view.

To generate the custom form:
Enter HEP-data-entry folder
```
yarn install
yarn build
node lib/cli.js --url='http://user:pwd!@dhisUrl'  --dataset-id='cLeSS7eAxN0' --module='module1_subnational_single_entry'
```

**Important**: the command uploads all data set to the server. 

### :bookmark_tabs: Others
