### PR TITLE
Move dicctionary to DataStore

### DIFF
--- a/HEP-data-entry/src/cli.ts
+++ b/HEP-data-entry/src/cli.ts
@@ -8,7 +8,7 @@ import { DataEntryForm } from "./models/d2Models";
 import { Dhis2Metadata, MetadataPayload, DataSet } from "./models/Dhis2Metadata";
 import SubnationalSingleCustomForm from "./components/module1_subnational_single/CustomForm";
 import { DataStoreClient } from "./data/DataStoreClient";
-import { CustomFormData } from "./components/snakebite/CustomFormData";
+import { CustomMetadata } from "./components/snakebite/CustomMetadata";
 
 type Module = "hepatitis" | "snakebite" | "module1_subnational_single_entry";
 
@@ -87,14 +87,16 @@ async function createCustomForm(dataSet: DataSet, module: Module, url: string) {
     if (module === "hepatitis") {
         return await AssembledFormHTML(dataSet);
     } else if (module === "snakebite") {
-        const dataStoreClient = new DataStoreClient(url, "snake-bite");
-        const customFormData = await dataStoreClient.get<CustomFormData>("customFormData");
+        const namespace = "snake-bite";
+        const key = "customMetadata";
+        const dataStoreClient = new DataStoreClient(url, namespace);
+        const customMetadata = await dataStoreClient.get<CustomMetadata>(key);
 
-        if (!customFormData) {
-            throw new Error(`Does not exist a required snake-bite namespace with a customFormData key in the data store`);
+        if (!customMetadata) {
+            throw new Error(`Does not exist a required ${namespace} namespace with a ${key} key in the data store`);
         }
 
-        return await SnakeBiteCustomForm(dataSet, customFormData);
+        return await SnakeBiteCustomForm(dataSet, customMetadata);
     } else if (module === "module1_subnational_single_entry") {
         return await SubnationalSingleCustomForm(dataSet);
     } else {

--- a/HEP-data-entry/src/components/common/EntryField.tsx
+++ b/HEP-data-entry/src/components/common/EntryField.tsx
@@ -17,7 +17,8 @@ export function EntryField(attributes: EntryFieldAttributes): string {
                 id={`${dataElementId}-${catComboId}-val`}
                 name="entryfield"
                 title={`${dataElementCode} ${catComboName}`}
-                value={`[ ${dataElementCode} ${catComboName} ]`}
+                class={"entryfield"}
+                type={"text"}
             />
             {helpMessage && (
                 <i

--- a/HEP-data-entry/src/components/snakebite/CustomMetadata.ts
+++ b/HEP-data-entry/src/components/snakebite/CustomMetadata.ts
@@ -10,7 +10,7 @@ interface OptionComboData {
     order?: number;
 }
 
-export interface CustomFormData {
+export interface CustomMetadata {
     dataElements: Record<string, DataElementData>;
     optionCombos: Record<string, OptionComboData>;
 }

--- a/HEP-data-entry/src/components/snakebite/DataElement.tsx
+++ b/HEP-data-entry/src/components/snakebite/DataElement.tsx
@@ -2,14 +2,15 @@ import { createElement } from "typed-html";
 import { SectionDataElement } from "../../models/d2Models";
 import { EntryField } from "../common/EntryField";
 import _ = require("lodash");
-import { customFormData } from "./customFormData";
+import { CustomFormData } from "./CustomFormData";
 
 interface DataElementAttributes {
+    customFormData: CustomFormData;
     dataElement: SectionDataElement;
 }
 
 export function DataElement(attributes: DataElementAttributes): string {
-    const { dataElement } = attributes;
+    const { dataElement, customFormData } = attributes;
 
     const tableAttributes = {
         border: "1",

--- a/HEP-data-entry/src/components/snakebite/DataElement.tsx
+++ b/HEP-data-entry/src/components/snakebite/DataElement.tsx
@@ -86,7 +86,6 @@ export function DataElement(attributes: DataElementAttributes): string {
                                 value={`[ ${dataElement.code} ]`}
                                 class={"entryfield"}
                                 type={"text"}
-                                style="width:80%;"
                             />
                         </th>
 

--- a/HEP-data-entry/src/components/snakebite/DataElement.tsx
+++ b/HEP-data-entry/src/components/snakebite/DataElement.tsx
@@ -2,15 +2,15 @@ import { createElement } from "typed-html";
 import { SectionDataElement } from "../../models/d2Models";
 import { EntryField } from "../common/EntryField";
 import _ = require("lodash");
-import { CustomFormData } from "./CustomFormData";
+import { CustomMetadata } from "./CustomMetadata";
 
 interface DataElementAttributes {
-    customFormData: CustomFormData;
+    customMetadata: CustomMetadata;
     dataElement: SectionDataElement;
 }
 
 export function DataElement(attributes: DataElementAttributes): string {
-    const { dataElement, customFormData } = attributes;
+    const { dataElement, customMetadata } = attributes;
 
     const tableAttributes = {
         border: "1",
@@ -21,7 +21,7 @@ export function DataElement(attributes: DataElementAttributes): string {
 
     const categoryOptionCombos = _.sortBy(
         dataElement.categoryCombo.categoryOptionCombos.map(catOpCombo => {
-            const catComboData = customFormData.optionCombos[catOpCombo.id];
+            const catComboData = customMetadata.optionCombos[catOpCombo.id];
 
             const order = catComboData ? catComboData.order : 0;
 
@@ -34,7 +34,7 @@ export function DataElement(attributes: DataElementAttributes): string {
         ["order"]
     );
 
-    const dataElementData = customFormData.dataElements[dataElement.id];
+    const dataElementData = customMetadata.dataElements[dataElement.id];
 
     return (
         <div>
@@ -62,7 +62,7 @@ export function DataElement(attributes: DataElementAttributes): string {
                                 : "Total"}
                         </th>
                         {categoryOptionCombos.map(catCombo => {
-                            const catComboData = customFormData.optionCombos[catCombo.id];
+                            const catComboData = customMetadata.optionCombos[catCombo.id];
 
                             return (
                                 <th scope="col" style="text-align: center;padding: 2px;">
@@ -76,7 +76,7 @@ export function DataElement(attributes: DataElementAttributes): string {
                 </thead>
                 <tbody>
                     <tr>
-                        <th scope="row" style="text-align: center;">
+                        <th scope="row" style="text-align: center;padding: 12px;">
                             <input
                                 {...{ dataelementid: dataElement.id }}
                                 id={`total${dataElement.id}`}
@@ -84,18 +84,20 @@ export function DataElement(attributes: DataElementAttributes): string {
                                 readonly="readonly"
                                 title={`${dataElement.code}`}
                                 value={`[ ${dataElement.code} ]`}
+                                class={"entryfield"}
+                                type={"text"}
                                 style="width:80%;"
                             />
                         </th>
 
                         {categoryOptionCombos.map(catCombo => {
-                            const catComboData = customFormData.optionCombos[catCombo.id];
+                            const catComboData = customMetadata.optionCombos[catCombo.id];
 
                             const helpMessage =
                                 catComboData && catComboData.info ? catComboData.info : undefined;
 
                             return (
-                                <td style="text-align: center;">
+                                <td style="text-align: center;padding: 12px;">
                                     <EntryField
                                         dataElementId={dataElement.id}
                                         dataElementCode={dataElement.code}

--- a/HEP-data-entry/src/components/snakebite/Sections.tsx
+++ b/HEP-data-entry/src/components/snakebite/Sections.tsx
@@ -1,12 +1,16 @@
 import { createElement } from "typed-html";
 import { DataElement } from "./DataElement";
 import { Section } from "../../models/d2Models";
+import { CustomFormData } from "./CustomFormData";
 
 interface SectionsAttributes {
+    customFormData: CustomFormData;
     sections: Section[];
 }
 
 export function Sections(attributes: SectionsAttributes): string {
+    const { customFormData } = attributes;
+
     return (
         <div>
             <h3>&nbsp;</h3>
@@ -23,7 +27,12 @@ export function Sections(attributes: SectionsAttributes): string {
 
                         {section.dataElements &&
                             section.dataElements.map(dataElement => {
-                                return <DataElement dataElement={dataElement} />;
+                                return (
+                                    <DataElement
+                                        dataElement={dataElement}
+                                        customFormData={customFormData}
+                                    />
+                                );
                             })}
 
                         <p>&nbsp;</p>

--- a/HEP-data-entry/src/components/snakebite/Sections.tsx
+++ b/HEP-data-entry/src/components/snakebite/Sections.tsx
@@ -1,15 +1,15 @@
 import { createElement } from "typed-html";
 import { DataElement } from "./DataElement";
 import { Section } from "../../models/d2Models";
-import { CustomFormData } from "./CustomFormData";
+import { CustomMetadata } from "./CustomMetadata";
 
 interface SectionsAttributes {
-    customFormData: CustomFormData;
+    customMetadata: CustomMetadata;
     sections: Section[];
 }
 
 export function Sections(attributes: SectionsAttributes): string {
-    const { customFormData } = attributes;
+    const { customMetadata } = attributes;
 
     return (
         <div>
@@ -30,7 +30,7 @@ export function Sections(attributes: SectionsAttributes): string {
                                 return (
                                     <DataElement
                                         dataElement={dataElement}
-                                        customFormData={customFormData}
+                                        customMetadata={customMetadata}
                                     />
                                 );
                             })}

--- a/HEP-data-entry/src/components/snakebite/SnakeBiteCustomForm.tsx
+++ b/HEP-data-entry/src/components/snakebite/SnakeBiteCustomForm.tsx
@@ -1,9 +1,9 @@
 import { createElement } from "typed-html";
 import { Sections } from "./Sections";
 import { DataSet } from "../../models/Dhis2Metadata";
-import { CustomFormData } from "./CustomFormData";
+import { CustomMetadata } from "./CustomMetadata";
 
-export function SnakeBiteCustomForm(dataSet: DataSet, customFormData: CustomFormData): string {
+export function SnakeBiteCustomForm(dataSet: DataSet, customMetadata: CustomMetadata): string {
     const javascript = `<script> 
                             $(function () {
                                 $("#tabs").tabs();
@@ -20,7 +20,7 @@ export function SnakeBiteCustomForm(dataSet: DataSet, customFormData: CustomForm
             {javascript}
 
             <div id="tabs">
-                <Sections sections={dataSet.sections} customFormData={customFormData} />
+                <Sections sections={dataSet.sections} customMetadata={customMetadata} />
             </div>
         </div>
     );

--- a/HEP-data-entry/src/components/snakebite/SnakeBiteCustomForm.tsx
+++ b/HEP-data-entry/src/components/snakebite/SnakeBiteCustomForm.tsx
@@ -1,8 +1,9 @@
 import { createElement } from "typed-html";
 import { Sections } from "./Sections";
 import { DataSet } from "../../models/Dhis2Metadata";
+import { CustomFormData } from "./CustomFormData";
 
-export function SnakeBiteCustomForm(dataSet: DataSet): string {
+export function SnakeBiteCustomForm(dataSet: DataSet, customFormData: CustomFormData): string {
     const javascript = `<script> 
                             $(function () {
                                 $("#tabs").tabs();
@@ -19,7 +20,7 @@ export function SnakeBiteCustomForm(dataSet: DataSet): string {
             {javascript}
 
             <div id="tabs">
-                <Sections sections={dataSet.sections} />
+                <Sections sections={dataSet.sections} customFormData={customFormData} />
             </div>
         </div>
     );

--- a/HEP-data-entry/src/components/snakebite/customFormData.ts
+++ b/HEP-data-entry/src/components/snakebite/customFormData.ts
@@ -10,51 +10,7 @@ interface OptionComboData {
     order?: number;
 }
 
-interface CustomFormData {
+export interface CustomFormData {
     dataElements: Record<string, DataElementData>;
     optionCombos: Record<string, OptionComboData>;
-}
-
-export const customFormData: CustomFormData = {
-    dataElements: {
-        "iS0UvvMJfBZ": { totalName: "Total reported cases" },
-        "c1ks4x7JXL3": { totalName: "Total reported cases" },
-        "eBvR8u3Zhyn": { totalName: "Total reported cases" },
-        "S0yO4CcyxGe": { totalName: "Total reported cases" },
-        "UHsqNgf8rMR": { totalName: "Total reported deaths" },
-        "SjTpTIWIQsf": { totalName: "Total reported deaths" },
-        "RQvWJjDJ75W": { totalName: "Total reported deaths" },
-        "jQL9yuvexE2": { totalName: "Total reported deaths" },
-        "Itk86F1EvYW": { totalName: "Total reported disabilities" },
-        "hgqaYbNBBji": { totalName: "Total reported disabilities" },
-        "fMyJYssme2o": { totalName: "Total reported disabilities" },
-        "GEQEMndn6Ns": { totalName: "Total reported disabilities" },
-        "HMr5QpcSo4C": {
-            totalName: "Number of WHO-recommended antivenom products",
-            info: "This field refers to the number of different antivenom products recommended by WHO in the reporting area, not the number of vials. WHO defines antivenom products as either monovalent (used to neutralise the venom of one specific snake species) or as polyvalent (more than one species)."
-        },
-        "Z4csnaklzkN": { totalName: "Number of other antivenom products" },
-        "bBEjzhEN4y9": {
-            totalName: "Total number of vials procured, considering all type of products",
-            info: "This is the number of vials of each product type - whether WHO-recommended or not."
-        },
-        "YxWD6KP10e2": { totalName: "Total number of vials of other products" },
-        "hLjVtUZKE6P": { totalName: "Total number of vials \n of WHO-recommended products" },
-    },
-    optionCombos: {
-        "Z2hvpF7mhh7": { name: "Total involving males", order: 1 },
-        "V2LdgcGgFQt": { name: "Total involving females", order: 2 },
-        "jNbFhhnUsQv": { name: "Total where sex not recorded", order: 3 },
-        "w4msAvzEdxS": { name: "Unknown population landscape" },
-        "rJdblRiSIO5": { order: 1, info: '"Clinical diagnosis": the number of cases where the attribution of "snakebite envenoming" is based on clinical examination and a determination that signs and symptoms are consistent with this diagnosis.' },
-        "R4MoCmzHuJd": { order: 2, info: '"Laboratory diagnosis": the number of cases where the  laboratory test results were used to help determine a diagnosis of snakebite envenoming' },
-        "a14nFkqYZ9i": { order: 3, info: '"Unknown diagnosis": cases where snakebite envenoming is listed as the diagnosis without any additional information.' },
-        "ZcIRFBDNEgJ": { order: 1 },
-        "btZqlaByU1i": { order: 2 },
-        "sWWzGtOIAc2": { order: 3 },
-        "MBcxsuUpEKw": { order: 4 },
-        "wqHO3LA1eKH": { order: 5 },
-        "vtFBssX7BTG": { order: 6 },
-
-    }
 }

--- a/HEP-data-entry/src/data/DataStoreClient.ts
+++ b/HEP-data-entry/src/data/DataStoreClient.ts
@@ -1,0 +1,30 @@
+import fetch from "node-fetch";
+import { safeParseJSON } from "../utils";
+
+export class DataStoreClient {
+    private baseUrl: string;
+
+    headers = { "Content-Type": "application/json" };
+
+    constructor(baseUrl: string, baseKey: string) {
+        this.baseUrl = baseUrl.replace(/\/*$/, "") + `/api/dataStore/${baseKey}`;
+    }
+
+    async get<T>(key: string): Promise<T | undefined> {
+        const url = `${this.baseUrl}/${key}`;
+        console.debug(`GET ${decodeURIComponent(url)}`);
+
+        const response = await fetch(url, {
+            method: "GET",
+            headers: this.headers,
+        });
+
+        if (response.status === 200) {
+            return safeParseJSON(response);
+        } else if (response.status === 404) {
+            return undefined;
+        } else {
+            throw Error(await response.text())
+        }
+    }
+}


### PR DESCRIPTION
### :pushpin: References
 https://app.clickup.com/t/buybcj
### :memo: Implementation

- I have created a DataStoreClient
- read customformMetadata from the data store

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?

It's necessary to create the snake-bite namespace with a customFormData key in the data store and with the content in this json:
[customMetadata.json.zip](https://github.com/EyeSeeTea/WHO-custom-forms/files/5750421/customMetadata.json.zip)

To generate Snakebite custom form is necessary changes in metadata:
- Create sections in the data set
- Rename formName in the data elements

To generate the custom form:
```
cd /HEP-data-entry
yarn build
node lib/cli.js --url='http://user:pwd!@dhisUrl' --dataset-id='XBgvNrxpcDC' --module='snakebite'
```

**Important**: the command uploads all data set to the server. 
**Important**: Sometimes to generate the custom form, age category options are duplicated in data elements. I think this is an API bug.

### :bookmark_tabs: Others

