### PR TITLE
Snakebite changes

### DIFF
--- a/HEP-data-entry/src/components/snakebite/CatOptionComboHeaderCell.tsx
+++ b/HEP-data-entry/src/components/snakebite/CatOptionComboHeaderCell.tsx
@@ -6,22 +6,37 @@ interface EntryFieldAttributes {
     catOptionComboId: string;
     catOptionComboName: string;
     helpMessage?: string;
+    backgroundColorByDE?: string;
+    colorByDE?: string;
 }
 
 export function CatOptionComboHeaderCell(attributes: EntryFieldAttributes): string {
-    const { customMetadata, catOptionComboId, catOptionComboName, helpMessage } = attributes;
+    const {
+        customMetadata,
+        catOptionComboId,
+        catOptionComboName,
+        helpMessage,
+        backgroundColorByDE = "",
+        colorByDE = "",
+    } = attributes;
 
     const catComboData = customMetadata.optionCombos[catOptionComboId];
 
+    const backgroundColor =
+        catComboData && catComboData.backgroundColor
+            ? `background-color:${catComboData.backgroundColor};`
+            : backgroundColorByDE;
+    const color = catComboData && catComboData.color ? `color:${catComboData.color};` : colorByDE;
+
     return (
-        <th>
+        <th style={backgroundColor + color}>
             <span>
                 {catComboData && catComboData.name ? catComboData.name : catOptionComboName}&nbsp;
             </span>
             {helpMessage && (
                 <i
                     class="fa fa-info-circle"
-                    style="font-size:16px;color:#276696;"
+                    style={"font-size:16px;" + backgroundColor + color}
                     id={`${catOptionComboId}-field-description`}
                     title={`${helpMessage}`}
                 ></i>

--- a/HEP-data-entry/src/components/snakebite/CatOptionCombosDataCells.tsx
+++ b/HEP-data-entry/src/components/snakebite/CatOptionCombosDataCells.tsx
@@ -23,7 +23,9 @@ export function CatOptionCombosDataCells(attributes: EntryFieldAttributes): stri
         : undefined;
 
     const totalCell =
-        customMetadataDE.showTotal === undefined || customMetadataDE.showTotal === true ? (
+        customMetadataDE === undefined ||
+        customMetadataDE.showTotal === undefined ||
+        customMetadataDE.showTotal === true ? (
             <td>
                 <input
                     {...(orgUnitDataElementAtt ? orgUnitDataElementAtt : dataElementAtt)}

--- a/HEP-data-entry/src/components/snakebite/CatOptionCombosDataCells.tsx
+++ b/HEP-data-entry/src/components/snakebite/CatOptionCombosDataCells.tsx
@@ -15,23 +15,32 @@ export function CatOptionCombosDataCells(attributes: EntryFieldAttributes): stri
 
     const categoryOptionCombos = sortCategoryOptionCombos(dataElement, customMetadata);
 
+    const customMetadataDE = customMetadata.dataElements[dataElement.id];
+
     const dataElementAtt = { dataelementid: dataElement.id };
     const orgUnitDataElementAtt = orgUnitId
         ? { subnationaltotalid: `${orgUnitId}-${dataElement.id}` }
         : undefined;
 
+    const totalCell =
+        customMetadataDE.showTotal === undefined || customMetadataDE.showTotal === true ? (
+            <td>
+                <input
+                    {...(orgUnitDataElementAtt ? orgUnitDataElementAtt : dataElementAtt)}
+                    id={`total${dataElement.id}`}
+                    name={orgUnitDataElementAtt ? "subnationalTotal" : "total"}
+                    readonly="readonly"
+                    title={`${dataElement.code}`}
+                    class={"entryfield"}
+                    type={"text"}
+                />
+            </td>
+        ) : (
+            ""
+        );
+
     return [
-        <td>
-            <input
-                {...(orgUnitDataElementAtt ? orgUnitDataElementAtt : dataElementAtt)}
-                id={`total${dataElement.id}`}
-                name={orgUnitDataElementAtt ? "subnationalTotal" : "total"}
-                readonly="readonly"
-                title={`${dataElement.code}`}
-                class={"entryfield"}
-                type={"text"}
-            />
-        </td>,
+        totalCell,
         ...categoryOptionCombos.map(catCombo => {
             return (
                 <td>

--- a/HEP-data-entry/src/components/snakebite/CatOptionCombosHeaderCells.tsx
+++ b/HEP-data-entry/src/components/snakebite/CatOptionCombosHeaderCells.tsx
@@ -16,10 +16,19 @@ export function CatOptionCombosHeaderCells(attributes: EntryFieldAttributes): st
 
     const categoryOptionCombos = sortCategoryOptionCombos(dataElement, customMetadata);
 
+    const totalHeader =
+        customMetadataDE.showTotal === undefined || customMetadataDE.showTotal === true ? (
+            <th>
+                {customMetadataDE && customMetadataDE.totalName
+                    ? customMetadataDE.totalName
+                    : "Total"}
+            </th>
+        ) : (
+            ""
+        );
+
     return [
-        <th>
-            {customMetadataDE && customMetadataDE.totalName ? customMetadataDE.totalName : "Total"}
-        </th>,
+        totalHeader,
         ...categoryOptionCombos.map(catCombo => {
             const catComboData = customMetadata.optionCombos[catCombo.id];
 

--- a/HEP-data-entry/src/components/snakebite/CatOptionCombosHeaderCells.tsx
+++ b/HEP-data-entry/src/components/snakebite/CatOptionCombosHeaderCells.tsx
@@ -16,9 +16,16 @@ export function CatOptionCombosHeaderCells(attributes: EntryFieldAttributes): st
 
     const categoryOptionCombos = sortCategoryOptionCombos(dataElement, customMetadata);
 
+    const backgroundColor =
+        customMetadataDE && customMetadataDE.backgroundColor
+            ? `background-color:${customMetadataDE.backgroundColor};`
+            : "";
+    const color =
+        customMetadataDE && customMetadataDE.color ? `color:${customMetadataDE.color};` : "";
+
     const totalHeader =
         customMetadataDE.showTotal === undefined || customMetadataDE.showTotal === true ? (
-            <th>
+            <th style={backgroundColor + color}>
                 {customMetadataDE && customMetadataDE.totalName
                     ? customMetadataDE.totalName
                     : "Total"}
@@ -39,6 +46,8 @@ export function CatOptionCombosHeaderCells(attributes: EntryFieldAttributes): st
                     catOptionComboId={catCombo.id}
                     catOptionComboName={catCombo.name}
                     helpMessage={helpMessage}
+                    backgroundColorByDE={backgroundColor}
+                    colorByDE={color}
                 />
             );
         }),

--- a/HEP-data-entry/src/components/snakebite/CatOptionCombosHeaderCells.tsx
+++ b/HEP-data-entry/src/components/snakebite/CatOptionCombosHeaderCells.tsx
@@ -24,7 +24,9 @@ export function CatOptionCombosHeaderCells(attributes: EntryFieldAttributes): st
         customMetadataDE && customMetadataDE.color ? `color:${customMetadataDE.color};` : "";
 
     const totalHeader =
-        customMetadataDE.showTotal === undefined || customMetadataDE.showTotal === true ? (
+        customMetadataDE === undefined ||
+        customMetadataDE.showTotal === undefined ||
+        customMetadataDE.showTotal === true ? (
             <th style={backgroundColor + color}>
                 {customMetadataDE && customMetadataDE.totalName
                     ? customMetadataDE.totalName

--- a/HEP-data-entry/src/components/snakebite/DataElement.tsx
+++ b/HEP-data-entry/src/components/snakebite/DataElement.tsx
@@ -24,10 +24,16 @@ export function DataElement(attributes: DataElementAttributes): string {
 
     return (
         <div>
-            <TableTitle
-                title={dataElement.formName}
-                info={dataElementData && dataElementData.info ? dataElementData.info : undefined}
-            />
+            {dataElementData.showName === undefined || dataElementData.showName === true ? (
+                <TableTitle
+                    title={dataElement.formName}
+                    info={
+                        dataElementData && dataElementData.info ? dataElementData.info : undefined
+                    }
+                />
+            ) : (
+                ""
+            )}
 
             <table {...tableAttributes} class="sectionTable">
                 <thead>

--- a/HEP-data-entry/src/components/snakebite/DataElement.tsx
+++ b/HEP-data-entry/src/components/snakebite/DataElement.tsx
@@ -24,7 +24,9 @@ export function DataElement(attributes: DataElementAttributes): string {
 
     return (
         <div>
-            {dataElementData.showName === undefined || dataElementData.showName === true ? (
+            {dataElementData === undefined ||
+            dataElementData.showName === undefined ||
+            dataElementData.showName === true ? (
                 <TableTitle
                     title={dataElement.formName}
                     info={

--- a/HEP-data-entry/src/components/snakebite/SnakeBiteCustomForm.tsx
+++ b/HEP-data-entry/src/components/snakebite/SnakeBiteCustomForm.tsx
@@ -119,7 +119,7 @@ export async function SnakeBiteCustomForm(
                                         No
                                     </input>
                                 </div>
-                                <div>
+                                <div id="form-recommended-container">
                                     <label for="recomended">Recommended</label>
                                     <input type="checkbox" name="recommended" disabled />
                                 </div>

--- a/HEP-data-entry/src/components/snakebite/resources/antivenom-products.js
+++ b/HEP-data-entry/src/components/snakebite/resources/antivenom-products.js
@@ -386,14 +386,15 @@ async function addEntryFieldsTableToGroup($group) {
     $(".remove-entry-fields").off("click");
     $(".remove-entry-fields").on("click", function(e) {
         e.preventDefault();
+        if (confirm("Are you sure? This will delete the reported value for the deleted row")) {
+            const $container = $(this).closest(".antivenom-table-container");
 
-        const $container = $(this).closest(".antivenom-table-container");
+            const $tr = $container.find("table tr");
 
-        const $tr = $container.find("table tr");
+            removeAntivenomDataValues($tr);
 
-        removeAntivenomDataValues($tr);
-
-        $container.remove();
+            $container.remove();
+        }
     });
 }
 

--- a/HEP-data-entry/src/components/snakebite/resources/custom-form.css
+++ b/HEP-data-entry/src/components/snakebite/resources/custom-form.css
@@ -60,6 +60,10 @@ input.text {
     padding: 0.3em;
 }
 
+#form-recommended-container {
+    visibility: hidden;
+}
+
 .radio-container {
     margin-bottom: 12px;
 }

--- a/HEP-data-entry/src/domain/snakebite/CustomMetadata.ts
+++ b/HEP-data-entry/src/domain/snakebite/CustomMetadata.ts
@@ -1,7 +1,8 @@
 interface DataElementData {
     name?: string;
-    totalName?: string;
     info?: string;
+    showName?: boolean,
+    totalName?: string;
 }
 
 interface OptionComboData {

--- a/HEP-data-entry/src/domain/snakebite/CustomMetadata.ts
+++ b/HEP-data-entry/src/domain/snakebite/CustomMetadata.ts
@@ -1,4 +1,6 @@
 interface DataElementData {
+    backgroundColor?: string;
+    color?: string;
     name?: string;
     info?: string;
     showTotal?: boolean,
@@ -7,6 +9,8 @@ interface DataElementData {
 }
 
 interface OptionComboData {
+    backgroundColor?: string;
+    color?: string;
     name?: string;
     info?: string;
     order?: number;

--- a/HEP-data-entry/src/domain/snakebite/CustomMetadata.ts
+++ b/HEP-data-entry/src/domain/snakebite/CustomMetadata.ts
@@ -1,6 +1,7 @@
 interface DataElementData {
     name?: string;
     info?: string;
+    showTotal?: boolean,
     showName?: boolean,
     totalName?: string;
 }


### PR DESCRIPTION
### :pushpin: References
https://app.clickup.com/t/buyh6f
### :memo: Implementation

#### General changes
- [x] Make it possible to decide the color of the header, so all "sign and symptoms rows render in orange" (Jorge)
- [x] Allow non-dissaggregated DEs / show/hide auto-calculated total (Jorge)
- [x] Hide DE title (Jorge)
#### Vials
- [ ] Represent the monovalent vs polyvalent as if it were a single DE, mutually exclusive, but keeping the current MD configuration because otherwise it won't be possible to represent that in analytics. (Jorge)
- [x] When adding a product remove the "Recommended" checkbox for the user...just don't display it (Jorge)
- [ ] After the selection of a product make all but the number of products non-editable (unless the information was not provided in the add product form) (Jorge)
- [x] When adding a product instead of "Add another WHO-recommended product"/"Add another non WHO-recommended product" show "Report another WHO-recommended product"/"Report another non WHO-recommended product" (Jorge)
- [x] When clicking in "Remove" to remove a row, show a pop-up asking for confirmation. "Are you sure? This will delete the reported value for the deleted row" (Jorge)
- [x] Put in bold "non WHO-recommended" so it's clear the difference with the WHO-recommended (Jorge)
#### Subnational
- [ ] Display the OU hierarchy instead of just the name of the OU (Jorge)
- [ ] Split into 3 tabs: one for "National", one for "Subnational epidemiological data" with the cases, and another one for "Subnational stock data" with the products (Jorge)

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?


#### Data Store

* CustomMetadata key changes:

1. dataElements - > New prop **showName** to hide the name for a data element. If not exists prop default value is true
2. dataElements - > New prop **showTotal** to hide the total column for a data element. If not exists prop default value is true
3. dataElements - > New prop **backgroundColor** for the header columns of a data element. 
4. dataElements - > New prop **color** for the header columns of a data element. 
5. optionCombos - > New prop **backgroundColor** for a specific column of a data element. This prop overwrite the same prop for data element for this column
6. optionCombos - > New prop **color** for a specific column of a data element. this prop overwrite the same prop for data element for this column. This prop overwrite the same prop for data element for this column

```js
{
   "dataElements": {
      "uidDE1": {
         "showTotal": // (for total column)
         "showName": // (for name title),
         "backgroundColor":"#e6a460",
         "color":"#FFFFFF"
      }
  },
   "optionCombos": {
      "uidCatOptionCombo1": {
         "backgroundColor":"#7085ea",
         "color":"#000000"
      }
   }
}
```

* AntivenomEntries changes:
1. Alexis add a new prop **name** by group. This field is only used from bulk load
2. changes in the title of the second group to mark as bold the text **non WHO-recommended**
3. Change the text to add new tables replacing the word ADD to REPORT
[antivenomEntries.json.zip](https://github.com/EyeSeeTea/WHO-custom-forms/files/5932123/antivenomEntries.json.zip)

 

#### To generate the custom form
```
cd /HEP-data-entry
yarn build
node lib/cli.js --url='http://user:pwd!@dhisUrl' --dataset-id='XBgvNrxpcDC' --module='snakebite'
```

**Important**: the command uploads all data set to the server. 
**Important**: Sometimes to generate the custom form, age category options are duplicated in data elements. I think this is an API bug.

### :bookmark_tabs: Others



