### PR TITLE
Snakebite changes phase 2

### DIFF
--- a/HEP-data-entry/src/components/common/EntryField.tsx
+++ b/HEP-data-entry/src/components/common/EntryField.tsx
@@ -6,7 +6,7 @@ interface EntryFieldAttributes {
     catComboId: string;
     catComboName: string;
     orgUnitId?: string;
-    type?: "radio" | "text";
+    type?: "radio" | "text" | "textArea";
     disabled?: string | boolean;
     hidden?: string | boolean;
     customAttributes?: any;
@@ -60,6 +60,19 @@ export function EntryField(attributes: EntryFieldAttributes): string {
                 //     style="cursor: pointer;"
                 // />,
             ].join("");
+        }
+        case "textArea": {
+            return (
+                <textarea
+                    {...customAttributes}
+                    hidden={hidden}
+                    id={`${id}-val`}
+                    name={!orgUnitId ? "entryfield" : ""}
+                    //title={`${dataElementCode} ${catComboName}`}
+                    class={!orgUnitId ? "entryfield" : ""}
+                    disabled={disabled}
+                />
+            );
         }
         default: {
             return (

--- a/HEP-data-entry/src/components/common/EntryField.tsx
+++ b/HEP-data-entry/src/components/common/EntryField.tsx
@@ -67,11 +67,12 @@ export function EntryField(attributes: EntryFieldAttributes): string {
                     {...customAttributes}
                     hidden={hidden}
                     id={`${id}-val`}
-                    name="entryfield"
+                    name={!orgUnitId ? "entryfield" : ""}
                     //title={`${dataElementCode} ${catComboName}`}
-                    class={"entryfield"}
+                    class={!orgUnitId ? "entryfield" : ""}
                     type={type}
                     disabled={disabled}
+                    style={"text-align: center;"}
                 />
             );
         }

--- a/HEP-data-entry/src/components/common/resources/sheetsee.js
+++ b/HEP-data-entry/src/components/common/resources/sheetsee.js
@@ -108,7 +108,7 @@ function searchTable(searchTerm) {
 // TABLE MAKING
 
 // Prep the data and pagination for the table
-function prepTable(filteredList) {
+function originalPrepTable(filteredList) {
     var data = filteredList || tblOpts.data;
 
     // If they don't specifiy pagination, draw table with everything
@@ -122,6 +122,39 @@ function prepTable(filteredList) {
     // If there is no data, don't paginate
     if (data.length === 0) addPaginationDOM(true);
     else addPaginationDOM();
+}
+
+function prepTable(filteredList) {
+    //Eyeseetea prepTable wrapper
+
+    if (tblOpts.onLoadingPage) {
+        var dir = tblOpts.pgnMta.dir || 0;
+        var currentPage = tblOpts.pgnMta.crntPage || 1;
+        var loadingPage = currentPage + dir;
+        onLoadingPage(loadingPage).then(data => {
+            tblOpts.data = data;
+
+            var data = filteredList || tblOpts.data;
+
+            // If they don't specifiy pagination, draw table with everything
+            if (!tblOpts.pagination) return updateTable(data);
+
+            // Create Pagination Metadata
+            buildPaginationMeta(data);
+            // Build the table with paginated data
+            updateTable(tblOpts.pgnMta.crntRows);
+
+            if (tblOpts.onLoadedPage) tblOpts.onLoadedPage();
+
+            // Append pagination DOM elements
+            // If there is no data, don't paginate
+            if (data.length === 0) addPaginationDOM(true);
+            else addPaginationDOM();
+        });
+    } else {
+        originalPrepTable(filteredList);
+        if (tblOpts.onLoadedPage) tblOpts.onLoadedPage();
+    }
 }
 
 function updateTable(data) {

--- a/HEP-data-entry/src/components/snakebite/CatOptionComboHeaderCell.tsx
+++ b/HEP-data-entry/src/components/snakebite/CatOptionComboHeaderCell.tsx
@@ -1,10 +1,13 @@
 import { createElement } from "typed-html";
 import { CustomMetadata } from "../../domain/snakebite/CustomMetadata";
 
+const defaultCatOptionComboId = "Xr12mI7VPn3";
+
 interface EntryFieldAttributes {
     customMetadata: CustomMetadata;
     catOptionComboId: string;
     catOptionComboName: string;
+    dataElementId: string;
     helpMessage?: string;
     backgroundColorByDE?: string;
     colorByDE?: string;
@@ -15,11 +18,13 @@ export function CatOptionComboHeaderCell(attributes: EntryFieldAttributes): stri
         customMetadata,
         catOptionComboId,
         catOptionComboName,
+        dataElementId,
         helpMessage,
         backgroundColorByDE = "",
         colorByDE = "",
     } = attributes;
 
+    const dataElementData = customMetadata.dataElements[dataElementId];
     const catComboData = customMetadata.optionCombos[catOptionComboId];
 
     const backgroundColor =
@@ -28,11 +33,19 @@ export function CatOptionComboHeaderCell(attributes: EntryFieldAttributes): stri
             : backgroundColorByDE;
     const color = catComboData && catComboData.color ? `color:${catComboData.color};` : colorByDE;
 
+    const nameByDataElement =
+        catOptionComboId === defaultCatOptionComboId &&
+        dataElementData &&
+        dataElementData.defaultCatOptionComboName
+            ? dataElementData.defaultCatOptionComboName
+            : undefined;
+
+    const nameByCatOptionCombo =
+        catComboData && catComboData.name ? catComboData.name : catOptionComboName;
+
     return (
         <th style={backgroundColor + color}>
-            <span>
-                {catComboData && catComboData.name ? catComboData.name : catOptionComboName}&nbsp;
-            </span>
+            <span>{nameByDataElement ? nameByDataElement : nameByCatOptionCombo}&nbsp;</span>
             {helpMessage && (
                 <i
                     class="fa fa-info-circle"

--- a/HEP-data-entry/src/components/snakebite/CatOptionCombosDataCells.tsx
+++ b/HEP-data-entry/src/components/snakebite/CatOptionCombosDataCells.tsx
@@ -52,6 +52,7 @@ export function CatOptionCombosDataCells(attributes: EntryFieldAttributes): stri
                         dataElementCode={dataElement.code}
                         catComboId={catCombo.id}
                         catComboName={catCombo.name}
+                        type={dataElement.valueType === "LONG_TEXT" ? "textArea" : "text"}
                     />
                 </td>
             );

--- a/HEP-data-entry/src/components/snakebite/CatOptionCombosHeaderCells.tsx
+++ b/HEP-data-entry/src/components/snakebite/CatOptionCombosHeaderCells.tsx
@@ -47,6 +47,7 @@ export function CatOptionCombosHeaderCells(attributes: EntryFieldAttributes): st
                     customMetadata={customMetadata}
                     catOptionComboId={catCombo.id}
                     catOptionComboName={catCombo.name}
+                    dataElementId={dataElement.id}
                     helpMessage={helpMessage}
                     backgroundColorByDE={backgroundColor}
                     colorByDE={color}

--- a/HEP-data-entry/src/components/snakebite/SubnationalSections.tsx
+++ b/HEP-data-entry/src/components/snakebite/SubnationalSections.tsx
@@ -83,7 +83,7 @@ export function SubnationalSections(attributes: SubnationalSectionsAttributes): 
                     <tbody>
                         {"{{#rows}}"}
                         <tr>
-                            <th>{"{{orgUnitName}}"}</th>
+                            <th>{"{{orgUnitPath}}"}</th>
                             {sections &&
                                 sections
                                     .map(section => {

--- a/HEP-data-entry/src/components/snakebite/SubnationalSections.tsx
+++ b/HEP-data-entry/src/components/snakebite/SubnationalSections.tsx
@@ -34,6 +34,7 @@ export function SubnationalSections(attributes: SubnationalSectionsAttributes): 
                                                     customMetadata.dataElements[dataElement.id];
 
                                                 const colspan =
+                                                    dataElementCustomMetadata &&
                                                     dataElementCustomMetadata.showTotal === false
                                                         ? dataElement.categoryCombo
                                                               .categoryOptionCombos.length

--- a/HEP-data-entry/src/components/snakebite/SubnationalSections.tsx
+++ b/HEP-data-entry/src/components/snakebite/SubnationalSections.tsx
@@ -30,12 +30,15 @@ export function SubnationalSections(attributes: SubnationalSectionsAttributes): 
                                     .map(section => {
                                         return section.dataElements
                                             .map(dataElement => {
-                                                const colspan =
-                                                    dataElement.categoryCombo.categoryOptionCombos
-                                                        .length + 1;
-
                                                 const dataElementCustomMetadata =
                                                     customMetadata.dataElements[dataElement.id];
+
+                                                const colspan =
+                                                    dataElementCustomMetadata.showTotal === false
+                                                        ? dataElement.categoryCombo
+                                                              .categoryOptionCombos.length
+                                                        : dataElement.categoryCombo
+                                                              .categoryOptionCombos.length + 1;
                                                 return (
                                                     <th colspan={colspan}>
                                                         {section.displayName +

--- a/HEP-data-entry/src/components/snakebite/resources/antivenom-products.js
+++ b/HEP-data-entry/src/components/snakebite/resources/antivenom-products.js
@@ -386,14 +386,15 @@ async function addEntryFieldsTableToGroup($group) {
     $(".remove-entry-fields").off("click");
     $(".remove-entry-fields").on("click", function(e) {
         e.preventDefault();
+        if (confirm("Are you sure? This will delete the reported value for the deleted row")) {
+            const $container = $(this).closest(".antivenom-table-container");
 
-        const $container = $(this).closest(".antivenom-table-container");
+            const $tr = $container.find("table tr");
 
-        const $tr = $container.find("table tr");
+            removeAntivenomDataValues($tr);
 
-        removeAntivenomDataValues($tr);
-
-        $container.remove();
+            $container.remove();
+        }
     });
 }
 

--- a/HEP-data-entry/src/components/snakebite/resources/antivenom-products.js
+++ b/HEP-data-entry/src/components/snakebite/resources/antivenom-products.js
@@ -67,14 +67,21 @@ function assignAntivenomDataValuesByProduct($tr, antivenomProduct) {
         if (prop && type && type === "radio") {
             if (antivenomProduct[prop] === true) {
                 markRadioInput(0);
+                $(this)
+                    .find(`input`)
+                    .prop("disabled", true);
             } else if (antivenomProduct[prop] === false) {
                 markRadioInput(1);
+                $(this)
+                    .find(`input`)
+                    .prop("disabled", true);
             }
         } else if (prop && type && type === "text" && antivenomProduct[prop]) {
             $(this)
                 .find(`input[id*=-val]`)
                 .val(antivenomProduct[prop])
-                .trigger("change");
+                .trigger("change")
+                .prop("disabled", true);
         }
     });
 }

--- a/HEP-data-entry/src/components/snakebite/resources/antivenom-products.js
+++ b/HEP-data-entry/src/components/snakebite/resources/antivenom-products.js
@@ -379,10 +379,8 @@ async function initializeByAdminUser($container) {
 }
 
 function convertMonovalentPolyvalentToExclusive($tr) {
-    debugger;
     $tr.find("input[type=radio]").off("mouseup");
     $tr.find("input[type=radio]").on("mouseup", function(e) {
-        debugger;
         if (!loadingAntivenomProductNames) {
             const id = $(this).attr("id");
             const value = $(this).val();
@@ -390,7 +388,6 @@ function convertMonovalentPolyvalentToExclusive($tr) {
                 .closest("tr")
                 .find("input[type=radio]")
                 .each(function() {
-                    debugger;
                     const opposedValue = value === "true" ? "false" : "true";
 
                     if ($(this).attr("id") !== id && opposedValue === $(this).val()) {

--- a/HEP-data-entry/src/components/snakebite/resources/antivenom-products.js
+++ b/HEP-data-entry/src/components/snakebite/resources/antivenom-products.js
@@ -153,6 +153,8 @@ async function onChangeAntivenomProduct(ev) {
         if (!loadingAntivenomProductNames) {
             assignAntivenomDataValuesByProduct($tr, antivenomProduct);
         }
+
+        convertMonovalentPolyvalentToExclusive($tr);
     } else {
         console.log("An error has ocurred finding selected product in product list");
     }
@@ -376,6 +378,30 @@ async function initializeByAdminUser($container) {
         });
 }
 
+function convertMonovalentPolyvalentToExclusive($tr) {
+    debugger;
+    $tr.find("input[type=radio]").off("mouseup");
+    $tr.find("input[type=radio]").on("mouseup", function(e) {
+        debugger;
+        if (!loadingAntivenomProductNames) {
+            const id = $(this).attr("id");
+            const value = $(this).val();
+            $(this)
+                .closest("tr")
+                .find("input[type=radio]")
+                .each(function() {
+                    debugger;
+                    const opposedValue = value === "true" ? "false" : "true";
+
+                    if ($(this).attr("id") !== id && opposedValue === $(this).val()) {
+                        $(this).prop("checked", true);
+                        $(this).addClass("checked");
+                    }
+                });
+        }
+    });
+}
+
 async function addEntryFieldsTableToGroup($group) {
     const template = $group.find(".table-template")[0];
 
@@ -425,6 +451,24 @@ function initializeAntivenomEntryFields() {
  * Add product form
  */
 
+function convertMonovalentPolyvalentFormToExclusive() {
+    $("#dialog-form input[type=radio]").off("click");
+    $("#dialog-form input[type=radio]").on("click", function(e) {
+        const name = $(this).attr("name");
+        const value = $(this).val();
+        $(this)
+            .closest("form")
+            .find("input[type=radio]")
+            .each(function() {
+                const opposedValue = value === "true" ? "false" : "true";
+
+                if ($(this).attr("name") !== name && opposedValue === $(this).val()) {
+                    $(this).prop("checked", true);
+                }
+            });
+    });
+}
+
 function resetFormMessage() {
     $("input[name=productName]").removeClass("ui-state-error");
     $("#form-message")
@@ -462,6 +506,7 @@ async function addAntivenomProduct(categoryOptionComboId) {
 }
 
 function initializeAddProductDialog() {
+    convertMonovalentPolyvalentFormToExclusive();
     addProductDialog = $("#dialog-form").dialog({
         autoOpen: false,
         height: 375,

--- a/HEP-data-entry/src/components/snakebite/resources/custom-form.css
+++ b/HEP-data-entry/src/components/snakebite/resources/custom-form.css
@@ -18,6 +18,11 @@
     background-color: #ffffff;
 }
 
+.cde table textarea {
+    min-width: 250px;
+    text-align: left;
+}
+
 .create-antivenom-product {
     margin-left: 8px;
 }

--- a/HEP-data-entry/src/components/snakebite/resources/custom-form.js
+++ b/HEP-data-entry/src/components/snakebite/resources/custom-form.js
@@ -6,13 +6,10 @@ async function initializeAndSelectAntivenomEntryFields() {
 }
 
 $(document).ready(function() {
-    $(function() {
-        $("#tabs").tabs({ active: 0 });
-    });
-
     initializeAddProductDialog();
 
     dhis2.util.on("dhis2.de.event.dataValuesLoaded", function(event, ds) {
+        $("#tabs").tabs({ active: 0 });
         renderSubnationalTab();
 
         loadIfUserIsAdmin().then(async () => {

--- a/HEP-data-entry/src/components/snakebite/resources/data.js
+++ b/HEP-data-entry/src/components/snakebite/resources/data.js
@@ -222,3 +222,21 @@ function getMe() {
         });
     });
 }
+
+function getOrgUnits(ids) {
+    return new Promise((resolve, reject) => {
+        $.ajax({
+            url: `../api/organisationUnits?fields=id,shortName&filter=id:in:[${ids.join(",")}]`,
+            type: "get",
+            dataType: "json",
+            success: json => {
+                resolve(json);
+            },
+            error: function(xhr) {
+                console.log("Error in the get getDataElement request");
+                console.log(xhr);
+                reject(xhr);
+            },
+        });
+    });
+}

--- a/HEP-data-entry/src/components/snakebite/resources/subnational-tab.js
+++ b/HEP-data-entry/src/components/snakebite/resources/subnational-tab.js
@@ -22,6 +22,13 @@ function onSubnationalInputChange(id) {
     updateSubnationalDataElementTotals(`${organisationUnitId}-${dataElementId}`);
 }
 
+function onSubnationalTextAreaChange(id) {
+    const dataElementId = id.split("-")[1];
+    const optionComboId = id.split("-")[2];
+
+    saveVal(dataElementId, optionComboId, id);
+}
+
 function renamePageOrgUnitPaths(currentPage) {
     if (orgUnits.length === 0) {
         return Promise.resolve(orgUnits);
@@ -105,6 +112,10 @@ function loadSubnationalValues() {
 
             $("#subnational input[type=text]").on("change", function(e) {
                 onSubnationalInputChange(e.target.id);
+            });
+            $("#subnational textarea").on("change", function(e) {
+                debugger;
+                onSubnationalTextAreaChange(e.target.id);
             });
 
             updateSubnationalDataElementTotals();


### PR DESCRIPTION
### :pushpin: References
https://app.clickup.com/t/buyh6f
### :memo: Implementation

#### Vials
- [x] Represent the monovalent vs polyvalent as if it were a single DE, mutually exclusive, but keeping the current MD provided in the add product form) (Jorge)
- [x] After the selection of a product make all but the number of products non-editable (unless the information was not provided in the add product form) (Jorge)
#### Subnational
- [x] Fix bug with col span when a total is hidden by data store
- [x] Display the OU hierarchy instead of just the name of the OU (Jorge)
- [ ] Split into 3 tabs: one for "National", one for "Subnational epidemiological data" with the cases, and another one for "Subnational stock data" with the products (Jorge)

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?
#### Metadata changes

Subnational tab use the same SQL view that HWF module 1 subnational single entry -> F9WNm3XNjli

This sql view change to return a new field **path** of the organisation unit

```sql
SELECT ou.uid, ou.shortname,ou.path
   FROM organisationunit ou
   LEFT JOIN datasetsource dss ON ou.organisationunitid = dss.sourceid
   LEFT JOIN dataset ds ON dss.datasetid = ds.datasetid
 WHERE ds.uid = '${dataSet}' and ou.path like '%${orgUnit}%'
 Order by ou.shortname ASC
```

#### Data Store

* CustomMetadata key changes:
new prop **defaultCatOptionComboName**, to customize column name for default category option combo

```js
  "dataElements": {
    "laW8yBtixac": {
      "defaultCatOptionComboName":"total 1",
    }
```

* AntivenomEntries changes:


#### To generate the custom form
```
cd /HEP-data-entry
yarn build
node lib/cli.js --url='http://user:pwd!@dhisUrl' --dataset-id='XBgvNrxpcDC' --module='snakebite'
```

**Important**: the command uploads all data set to the server. 
**Important**: Sometimes to generate the custom form, age category options are duplicated in data elements. I think this is an API bug.

### :bookmark_tabs: Others



