### PR TITLE
Show two tabs for subnational

### DIFF
--- a/HEP-data-entry/src/components/common/resources/sheetseeV2.js
+++ b/HEP-data-entry/src/components/common/resources/sheetseeV2.js
@@ -1,0 +1,254 @@
+// **** sheetsee-tables ****
+// https://github.com/jlord/sheetsee-tables/blob/master/index.js
+// I have not found a cdn to download by scrript link
+// I try https://cdn.rawgit.com/jlord/sheetsee.js/master/js/sheetsee.js but fail sometimes
+class Sheetsee {
+    tblOpts = {};
+
+    // Only called the very first time
+    makeTable(data) {
+        this.tblOpts = data;
+        this.tblOpts.sortMeta = {};
+        this.tblOpts.pgnMta = {};
+
+        if (!this.tblOpts.templateID) {
+            this.tblOpts.templateID = this.tblOpts.tableDiv.replace("#", "") + "_template";
+        }
+
+        this.buildPaginationMeta(data.data, data.pagination);
+
+        this.prepTable();
+        this.initiateTableSorter();
+    }
+
+    // SORTING
+
+    // Called once to listen for clicks on table headers
+    initiateTableSorter() {
+        document.body.addEventListener("click", function(event) {
+            if (event.target.classList.contains("tHeader")) {
+                perpareSort(event);
+            }
+        });
+    }
+
+    // Prepare to be sorted
+    perpareSort(event) {
+        if (!this.tblOpts.sortMeta.sorted || this.tblOpts.sortMeta.sorted === "descending") {
+            this.tblOpts.sortMeta.sorted = "ascending";
+        } else if (this.tblOpts.sortMeta.sorted === "ascending")
+            this.tblOpts.sortMeta.sorted = "descending";
+        // TODO maybe make all keys in data lowercase...
+        this.tblOpts.sortMeta.sortBy = event.target.innerHTML.replace(/\s/g, "").replace(/\W/g, "");
+        this.tblOpts.tableDiv = "#" + event.target.closest("div").getAttribute("id");
+        this.sortData();
+    }
+
+    // Sort the data
+    sortData() {
+        let sortGroup;
+        if (this.tblOpts.filtering) sortGroup = this.tblOpts.pgnMta.allRows;
+        else sortGroup = this.tblOpts.data;
+
+        sortGroup.sort(function(a, b) {
+            const aa = a[this.tblOpts.sortMeta.sortBy].toLowerCase();
+            const bb = b[this.tblOpts.sortMeta.sortBy].toLowerCase();
+            aa = aa.match(/^[\d,]$/) ? Number(aa) : aa;
+            bb = bb.match(/^[\d,]$/) ? Number(bb) : bb;
+
+            if (aa < bb) return -1;
+            if (aa > bb) return 1;
+            return 0;
+        });
+        if (this.tblOpts.sortMeta.sorted === "descending") sortGroup.reverse();
+        // This table update doesn't change pagination; reset direction
+        if (this.tblOpts.pgnMta.dir) this.tblOpts.pgnMta.dir = Number(0);
+        // If the table has been filtered, just sort those
+        if (this.tblOpts.filtering) prepTable(this.tblOpts.pgnMta.allRows);
+        else this.prepTable();
+    }
+
+    // FITERING
+
+    // Set up listeners for clear and input
+    initiateTableFilter(options) {
+        // If things are missing, return
+        if (document.querySelector(".clear") === null) return;
+        if (!options.filterDiv) return;
+        if (document.getElementById(options.filterDiv.replace("#", "")) === null) return;
+
+        this.tblOpts.filtering = true;
+        const filterInput = document.getElementById(options.filterDiv.replace("#", ""));
+
+        // listen for clicks on clear button
+        document.querySelector(".clear").addEventListener("click", function() {
+            filterInput.value = "";
+            // This resets the table to initial direction
+            if (this.tblOpts.pgnMta.dir) this.tblOpts.pgnMta.dir = Number(0);
+            // TODO should it reset to page 1
+            this.prepTable();
+        });
+        // Listen for input in the serach field
+        filterInput.addEventListener("keyup", function(e) {
+            this.searchTable(e.target.value);
+        });
+    }
+
+    // Search the table with input
+    searchTable(searchTerm) {
+        const filteredList = [];
+        this.tblOpts.data.forEach(function(object) {
+            const stringObject = JSON.stringify(object).toLowerCase();
+            if (stringObject.match(searchTerm.toLowerCase())) filteredList.push(object);
+        });
+        // Clear direction and page
+        if (this.tblOpts.pgnMta.dir) this.tblOpts.pgnMta.dir = Number(0);
+        if (this.tblOpts.pgnMta.crntPage) this.tblOpts.pgnMta.crntPage = Number(1);
+        this.prepTable(filteredList);
+    }
+
+    // TABLE MAKING
+
+    // Prep the data and pagination for the table
+    originalPrepTable(filteredList) {
+        const data = filteredList || this.tblOpts.data;
+
+        // If they don't specifiy pagination, draw table with everything
+        if (!this.tblOpts.pagination) return this.updateTable(data);
+
+        // Create Pagination Metadata
+        this.buildPaginationMeta(data);
+        // Build the table with paginated data
+        this.updateTable(this.tblOpts.pgnMta.crntRows);
+        // Append pagination DOM elements
+        // If there is no data, don't paginate
+        if (data.length === 0) addPaginationDOM(true);
+        else thsi.addPaginationDOM();
+    }
+
+    prepTable(filteredList) {
+        //Eyeseetea prepTable wrapper
+
+        if (this.tblOpts.onLoadingPage) {
+            const dir = this.tblOpts.pgnMta.dir || 0;
+            const currentPage = this.tblOpts.pgnMta.crntPage || 1;
+            const loadingPage = currentPage + dir;
+            this.tblOpts.onLoadingPage(loadingPage).then(dataResponse => {
+                this.tblOpts.data = dataResponse;
+
+                const data = filteredList || this.tblOpts.data;
+
+                // If they don't specifiy pagination, draw table with everything
+                if (!this.tblOpts.pagination) return this.updateTable(data);
+
+                // Create Pagination Metadata
+                this.buildPaginationMeta(data);
+                // Build the table with paginated data
+                this.updateTable(this.tblOpts.pgnMta.crntRows);
+
+                // Append pagination DOM elements
+                // If there is no data, don't paginate
+                if (data.length === 0) {
+                    this.addPaginationDOM(true);
+                } else {
+                    this.addPaginationDOM();
+                }
+
+                if (this.tblOpts.onLoadedPage) {
+                    this.tblOpts.onLoadedPage();
+                }
+            });
+        } else {
+            this.originalPrepTable(filteredList);
+            if (this.tblOpts.onLoadedPage) this.tblOpts.onLoadedPage();
+        }
+    }
+
+    updateTable(data) {
+        const rawTemplate = document.getElementById(this.tblOpts.templateID).innerHTML;
+        const content = Mustache.render(rawTemplate, { rows: data });
+        document.getElementById(this.tblOpts.tableDiv).innerHTML = content;
+    }
+
+    // PAGINATION
+
+    // Create the metadata used in pagination
+    buildPaginationMeta(data) {
+        const dir = this.tblOpts.pgnMta.dir || 0;
+        const current = this.tblOpts.pgnMta.crntPage || 1;
+        this.tblOpts.pgnMta.allRows = data;
+        this.tblOpts.pgnMta.allRowsLen = data.length;
+        this.tblOpts.pgnMta.totalPages = Math.ceil(
+            this.tblOpts.pgnMta.allRowsLen / this.tblOpts.pagination
+        );
+        this.tblOpts.pgnMta.crntPage = current + dir;
+        this.tblOpts.pgnMta.nextPage = this.tblOpts.pgnMta.crntPage - 1;
+        this.tblOpts.pgnMta.crntStart =
+            this.tblOpts.pgnMta.crntPage * this.tblOpts.pagination - this.tblOpts.pagination;
+        this.tblOpts.pgnMta.crntEnd = this.tblOpts.pgnMta.crntPage * this.tblOpts.pagination;
+        this.tblOpts.pgnMta.crntRows = data.slice(
+            this.tblOpts.pgnMta.crntStart,
+            this.tblOpts.pgnMta.crntEnd
+        );
+        return;
+    }
+
+    // Add pagination elements and listeners to the DOM
+    addPaginationDOM(nopages) {
+        const tblId = this.tblOpts.tableDiv.slice(1);
+        const el = document.createElement("div");
+        el.setAttribute("id", "Pagination");
+        el.setAttribute("pageno", this.tblOpts.pgnMta.crntPage);
+        el.classList.add("table-pagination");
+        if (nopages) {
+            el.innerHTML = "No results</div>";
+        } else if (this.tblOpts.pgnMta.allRowsLen <= this.tblOpts.pagination) {
+            el.innerHTML = "Page 1 of 1</div>";
+        } else {
+            el.innerHTML =
+                "Showing page " +
+                this.tblOpts.pgnMta.crntPage +
+                " of " +
+                this.tblOpts.pgnMta.totalPages +
+                " <a class='pagination-pre pagination-pre-" +
+                tblId +
+                "'>Previous</a>" +
+                " <a class='pagination-next pagination-next-" +
+                tblId +
+                "'>Next</a></div>";
+        }
+        document.getElementById("#" + tblId).append(el);
+        // Don't show pagination in these cases TODO clean up
+        if (nopages) return;
+        if (this.tblOpts.pgnMta.allRowsLen <= this.tblOpts.pagination) return;
+
+        // On the last page
+        if (this.tblOpts.pgnMta.crntPage >= this.tblOpts.pgnMta.totalPages) {
+            document.querySelector(".pagination-next-" + tblId).classList.add("no-pag");
+            document.querySelector(".pagination-pre-" + tblId).classList.remove("no-pag");
+        }
+        // On the first page
+        if (this.tblOpts.pgnMta.crntPage === 1) {
+            document.querySelector(".pagination-pre-" + tblId).classList.add("no-pag");
+            document.querySelector(".pagination-next-" + tblId).classList.remove("no-pag");
+        }
+        // Listen for next clicks
+        document.querySelector(".pagination-next-" + tblId).addEventListener("click", e => {
+            if (e.target.classList.contains("no-pag")) return;
+            this.tblOpts.pgnMta.dir = Number(1);
+            // if there is text in the search and you are paginating
+            // through filtered data, build table with what is in paginationmeta data
+            if (this.tblOpts.filtering) prepTable(this.tblOpts.pgnMta.allRows);
+            else this.prepTable();
+        });
+        // Listen for previous clicks
+        document.querySelector(".pagination-pre-" + tblId).addEventListener("click", e => {
+            if (e.target.classList.contains("no-pag")) return;
+            this.tblOpts.pgnMta.dir = Number(-1);
+            // if there is text in the search and you are paginating
+            // through filtered data, build table with what is in paginationmeta data
+            if (this.tblOpts.filtering) prepTable(this.tblOpts.pgnMta.allRows);
+            else this.prepTable();
+        });
+    }
+}

--- a/HEP-data-entry/src/components/snakebite/SnakeBiteCustomForm.tsx
+++ b/HEP-data-entry/src/components/snakebite/SnakeBiteCustomForm.tsx
@@ -14,7 +14,8 @@ import {
 
 export async function SnakeBiteCustomForm(
     dataSet: DataSet,
-    subnationalDataSet: DataSet,
+    subnationalStockDataDataSet: DataSet,
+    subnationalEpidemiologicalDataDataSet: DataSet,
     customMetadata: CustomMetadata,
     antivenomEntries: AntivenomEntries
 ): Promise<string> {
@@ -23,11 +24,20 @@ export async function SnakeBiteCustomForm(
     const subnationalTabJS = await getResource("resources/subnational-tab.js");
     const antivenomProductsJS = await getResource("resources/antivenom-products.js");
     const customFormJS = await getResource("resources/custom-form.js");
-    const sheetseeJs = await getResource("../common/resources/sheetsee.js");
+    const sheetseeJs = await getResource("../common/resources/sheetseeV2.js");
+
+    const stockDataName = customMetadata.subnationalStockDataDataSet.name
+        ? customMetadata.subnationalStockDataDataSet.name
+        : "Subnational";
+    const epidemiologicalDataName = customMetadata.subnationalEpidemiologicalDataDataSet.name
+        ? customMetadata.subnationalEpidemiologicalDataDataSet.name
+        : "Subnational";
 
     return (
         <div>
+            <script src="https://unpkg.com/mustache@4.0.1"></script>
             <style>${style}</style>
+            <script>${sheetseeJs}</script>
             <script
                 id="data-script"
                 type="text/javascript"
@@ -41,13 +51,13 @@ export async function SnakeBiteCustomForm(
             <script
                 id="subnational-tab-script"
                 type="text/javascript"
-                data-subnational-dataset-id={`${subnationalDataSet.id}`}
+                data-subnational-stock-data-dataset-id={`${subnationalStockDataDataSet.id}`}
+                data-subnational-epidemiological-data-dataset-id={`${subnationalStockDataDataSet.id}`}
             >
                 ${subnationalTabJS}
             </script>
             <script>${antivenomProductsJS}</script>
             <script>${customFormJS}</script>
-            <script>${sheetseeJs}</script>
             <h2>
                 SNAKE BITE ENVENOMING
                 <br />
@@ -59,7 +69,10 @@ export async function SnakeBiteCustomForm(
                         <a href="#tab0">National</a>
                     </li>
                     <li>
-                        <a href="#tab1">Subnational</a>
+                        <a href="#tab1">{epidemiologicalDataName}</a>
+                    </li>
+                    <li>
+                        <a href="#tab2">{stockDataName}</a>
                     </li>
                 </ul>
 
@@ -127,9 +140,25 @@ export async function SnakeBiteCustomForm(
                         </form>
                     </div>
                 </div>
-                <div id="tab1">
+                <div
+                    id="tab1"
+                    class="subnational-tab"
+                    data-dataset={subnationalEpidemiologicalDataDataSet.id}
+                >
                     <SubnationalSections
-                        sections={subnationalDataSet.sections}
+                        subnationalDataSetId={subnationalEpidemiologicalDataDataSet.id}
+                        sections={subnationalEpidemiologicalDataDataSet.sections}
+                        customMetadata={customMetadata}
+                    />
+                </div>
+                <div
+                    id="tab2"
+                    class="subnational-tab"
+                    data-dataset={subnationalStockDataDataSet.id}
+                >
+                    <SubnationalSections
+                        subnationalDataSetId={subnationalStockDataDataSet.id}
+                        sections={subnationalStockDataDataSet.sections}
                         customMetadata={customMetadata}
                     />
                 </div>

--- a/HEP-data-entry/src/components/snakebite/SubnationalSections.tsx
+++ b/HEP-data-entry/src/components/snakebite/SubnationalSections.tsx
@@ -6,11 +6,12 @@ import { CustomMetadata } from "../../domain/snakebite/CustomMetadata";
 
 interface SubnationalSectionsAttributes {
     customMetadata: CustomMetadata;
+    subnationalDataSetId: string;
     sections: Section[];
 }
 
 export function SubnationalSections(attributes: SubnationalSectionsAttributes): string {
-    const { sections, customMetadata } = attributes;
+    const { sections, subnationalDataSetId, customMetadata } = attributes;
 
     const tableAttributes = {
         border: "1",
@@ -19,8 +20,7 @@ export function SubnationalSections(attributes: SubnationalSectionsAttributes): 
 
     const html = (
         <div>
-            <script src="https://unpkg.com/mustache@4.0.1"></script>
-            <script id="orgUnitsTable_template" type="x-tmpl-mustache">
+            <script id={`${subnationalDataSetId}_template`} type="x-tmpl-mustache">
                 <table {...tableAttributes} class="sectionTablesss">
                     <thead>
                         <tr>
@@ -107,7 +107,7 @@ export function SubnationalSections(attributes: SubnationalSectionsAttributes): 
                 </table>
             </script>
             <div id="subnational">
-                <div id="orgUnitsTable" class="cde"></div>
+                <div id={`#${subnationalDataSetId}_table`} class="cde"></div>
                 <div id="custom-form-loader">
                     <img id="loader" src="../images/ajax-loader-circle.gif" />
 

--- a/HEP-data-entry/src/components/snakebite/SubnationalSections.tsx
+++ b/HEP-data-entry/src/components/snakebite/SubnationalSections.tsx
@@ -40,11 +40,22 @@ export function SubnationalSections(attributes: SubnationalSectionsAttributes): 
                                                               .categoryOptionCombos.length
                                                         : dataElement.categoryCombo
                                                               .categoryOptionCombos.length + 1;
+
+                                                const showDEName =
+                                                    dataElementCustomMetadata === undefined ||
+                                                    dataElementCustomMetadata.showName ===
+                                                        undefined ||
+                                                    dataElementCustomMetadata.showName === true;
+
+                                                const name = showDEName
+                                                    ? section.displayName +
+                                                      " - " +
+                                                      dataElement.formName
+                                                    : section.displayName;
+
                                                 return (
                                                     <th colspan={colspan}>
-                                                        {section.displayName +
-                                                            " - " +
-                                                            dataElement.formName}
+                                                        {name}
 
                                                         {dataElementCustomMetadata &&
                                                         dataElementCustomMetadata.info ? (

--- a/HEP-data-entry/src/components/snakebite/resources/custom-form.css
+++ b/HEP-data-entry/src/components/snakebite/resources/custom-form.css
@@ -121,15 +121,15 @@ input.text {
     font-size: 14px;
 }
 
-#subnational .pagination-next-orgUnitsTable:hover,
-#subnational .pagination-pre-orgUnitsTable:hover {
+#subnational .pagination-next:hover,
+#subnational .pagination-pre:hover {
     background: black;
     color: white;
     text-decoration: none;
 }
 
-#subnational .pagination-next-orgUnitsTable,
-#subnational .pagination-pre-orgUnitsTable {
+#subnational .pagination-next,
+#subnational .pagination-pre {
     box-sizing: border-box;
     display: inline-block;
     text-align: center;

--- a/HEP-data-entry/src/components/snakebite/resources/custom-form.js
+++ b/HEP-data-entry/src/components/snakebite/resources/custom-form.js
@@ -9,8 +9,24 @@ $(document).ready(function() {
     initializeAddProductDialog();
 
     dhis2.util.on("dhis2.de.event.dataValuesLoaded", function(event, ds) {
+        selectedOrgUnitId = dhis2.de.currentOrganisationUnitId;
         $("#tabs").tabs({ active: 0 });
-        renderSubnationalTab();
+
+        const subnationalTabs = [];
+
+        $(".subnational-tab").each(function() {
+            const subnationalDataSetId = $(this).data("dataset");
+
+            subnationalTabs.push(
+                new SubnationalTab(
+                    $(this),
+                    subnationalDataSetId,
+                    dhis2.de.currentOrganisationUnitId
+                )
+            );
+        });
+
+        subnationalTabs.forEach(tab => tab.render());
 
         loadIfUserIsAdmin().then(async () => {
             initializeAndSelectAntivenomEntryFields();

--- a/HEP-data-entry/src/components/snakebite/resources/subnational-tab.js
+++ b/HEP-data-entry/src/components/snakebite/resources/subnational-tab.js
@@ -1,185 +1,208 @@
-var orgUnits = [];
-var pageSize = 10;
+class SubnationalTab {
+    orgUnits = [];
+    pageSize = 10;
 
-function updateSubnationalDataElementTotals(orgUnitDataElementId) {
-    $('input[name="subnationalTotal"]').each(function() {
-        var totalId = $(this).attr("subnationaltotalid");
-
-        if (!orgUnitDataElementId || orgUnitDataElementId == totalId) {
-            var total = dhis2.de.getDataElementTotalValue(totalId);
-
-            $(this).val(total);
-        }
-    });
-}
-
-function onSubnationalInputChange(id) {
-    const organisationUnitId = id.split("-")[0];
-    const dataElementId = id.split("-")[1];
-    const optionComboId = id.split("-")[2];
-
-    saveVal(dataElementId, optionComboId, id);
-    updateSubnationalDataElementTotals(`${organisationUnitId}-${dataElementId}`);
-}
-
-function onSubnationalTextAreaChange(id) {
-    const dataElementId = id.split("-")[1];
-    const optionComboId = id.split("-")[2];
-
-    saveVal(dataElementId, optionComboId, id);
-}
-
-function renamePageOrgUnitPaths(currentPage) {
-    if (orgUnits.length === 0) {
-        return Promise.resolve(orgUnits);
-    } else {
-        const orgUnitIds = [
-            ...new Set(
-                orgUnits
-                    .slice(currentPage * pageSize - pageSize, currentPage * pageSize)
-                    .map(ou => ou.orgUnitPath.split("/"))
-                    .flat()
-                    .filter(uid => isValidUid(uid))
-            ),
-        ];
-
-        if (orgUnitIds.length === 0) return Promise.resolve(orgUnits);
-
-        return getOrgUnits(orgUnitIds).then(orgUnitNames => {
-            orgUnits = orgUnits.map(ou => {
-                const ouPath = ou.orgUnitPath.split("/");
-                const ouPathNames = ouPath
-                    .map(id => {
-                        const orgUnit = orgUnitNames.organisationUnits.find(ou => ou.id === id);
-                        return orgUnit ? orgUnit.shortName : id;
-                    })
-                    .join(" / ");
-
-                return { ...ou, orgUnitPath: ouPathNames };
-            });
-
-            return orgUnits;
-        });
-    }
-}
-
-function loadSubnationalValues() {
-    const $nextPageButton = document.querySelector(".pagination-next-orgUnitsTable");
-
-    if ($nextPageButton) {
-        $nextPageButton.addEventListener("click", function(e) {
-            if (e.target.classList.contains("no-pag")) return;
-
-            loadSubnationalValues();
-        });
+    constructor($tabContainer, subnationalDataSetId, selectedOrgUnitId) {
+        this.subnationalDataSetId = subnationalDataSetId;
+        this.$tabContainer = $tabContainer;
+        this.tableConatinerId = `${subnationalDataSetId}_table`;
+        this.selectedOrgUnitId = selectedOrgUnitId;
     }
 
-    const $previousPageButton = document.querySelector(".pagination-pre-orgUnitsTable");
+    updateSubnationalDataElementTotals(orgUnitDataElementId) {
+        this.$tabContainer.find('input[name="subnationalTotal"]').each(function() {
+            const totalId = $(this).attr("subnationaltotalid");
 
-    if ($previousPageButton) {
-        $previousPageButton.addEventListener("click", function(e) {
-            if (e.target.classList.contains("no-pag")) return;
+            if (!orgUnitDataElementId || orgUnitDataElementId == totalId) {
+                const total = dhis2.de.getDataElementTotalValue(totalId);
 
-            loadSubnationalValues();
-        });
-    }
-
-    var periodId = $("#selectedPeriodId").val();
-
-    var params = {
-        period: periodId,
-        dataSet: $("#subnational-tab-script").attr("data-subnational-dataset-id"),
-        orgUnit: dhis2.de.getCurrentOrganisationUnit(),
-        children: true,
-    };
-
-    $.ajax({
-        url: "../api/dataValueSets",
-        data: params,
-        dataType: "json",
-        success: json => {
-            $.safeEach(json.dataValues, function(i, dataValue) {
-                var fieldId = `#${dataValue.orgUnit}-${dataValue.dataElement}-${dataValue.categoryOptionCombo}-val`;
-                if ($(fieldId).length > 0) {
-                    var entryField = $(fieldId);
-                    if ("true" == dataValue.value && entryField.attr("type") == "checkbox") {
-                        $(fieldId).prop("checked", true);
-                    } else {
-                        $(fieldId).val(dataValue.value);
-                    }
-                }
-            });
-
-            $("#subnational input[type=text]").on("change", function(e) {
-                onSubnationalInputChange(e.target.id);
-            });
-            $("#subnational textarea").on("change", function(e) {
-                debugger;
-                onSubnationalTextAreaChange(e.target.id);
-            });
-
-            updateSubnationalDataElementTotals();
-        },
-        error: function(xhr) {
-            console.log("Error in the request");
-            console.log(xhr);
-        },
-    });
-}
-
-function isValidUid(value) {
-    const UID_PATTERN = /^[a-zA-Z]{1}[a-zA-Z0-9]{10}$/;
-
-    return UID_PATTERN.test(value);
-}
-
-function onLoadingPage(page) {
-    return renamePageOrgUnitPaths(page);
-}
-
-function onLoadedPage() {
-    loadSubnationalValues();
-}
-
-function renderSubnationalTab() {
-    $("#subnational .cde table tbody").empty();
-    $("#custom-form-loader").show();
-
-    const subnationalDataSetId = $("#subnational-tab-script").attr("data-subnational-dataset-id");
-
-    const filter = `paging=false&var=dataSet:${subnationalDataSetId}&var=orgUnit:${dhis2.de.currentOrganisationUnitId}`;
-
-    $.ajax({
-        url: `../api/sqlViews/F9WNm3XNjli/data?${filter}`,
-        type: "get",
-        success: function(response) {
-            orgUnits = response.listGrid.rows.map(row => ({
-                orgUnitId: row[0],
-                orgUnitName: row[1],
-                orgUnitPath: row[2],
-            }));
-
-            if (orgUnits.length > 0) {
-                $("#tabs-list").show();
-                var tableOptions = {
-                    data: orgUnits,
-                    pagination: pageSize,
-                    tableDiv: "#orgUnitsTable",
-                    templateID: "orgUnitsTable_template",
-                    onLoadingPage,
-                    onLoadedPage,
-                };
-
-                makeTable(tableOptions);
-
-                $("#custom-form-loader").hide();
-            } else {
-                $("#tabs-list").hide();
+                $(this).val(total);
             }
-        },
-        error: function(xhr) {
-            console.log("Error in the request");
-            console.log(xhr);
-        },
-    });
+        });
+    }
+
+    onSubnationalInputChange(id) {
+        const organisationUnitId = id.split("-")[0];
+        const dataElementId = id.split("-")[1];
+        const optionComboId = id.split("-")[2];
+
+        saveVal(dataElementId, optionComboId, id);
+        this.updateSubnationalDataElementTotals(`${organisationUnitId}-${dataElementId}`);
+    }
+
+    onSubnationalTextAreaChange(id) {
+        const dataElementId = id.split("-")[1];
+        const optionComboId = id.split("-")[2];
+
+        saveVal(dataElementId, optionComboId, id);
+    }
+
+    renamePageOrgUnitPaths(currentPage) {
+        if (this.orgUnits.length === 0) {
+            return Promise.resolve(this.orgUnits);
+        } else {
+            const orgUnitsToRender = () => [
+                ...this.orgUnits.map(ou => ({
+                    ...ou,
+                    orgUnitPath: ou.orgUnitPath.replaceAll("/", " / "),
+                })),
+            ];
+
+            const orgUnitIds = [
+                ...new Set(
+                    this.orgUnits
+                        .slice(
+                            currentPage * this.pageSize - this.pageSize,
+                            currentPage * this.pageSize
+                        )
+                        .map(ou => ou.orgUnitPath.split("/"))
+                        .flat()
+                        .filter(uid => this.isValidUid(uid))
+                ),
+            ];
+
+            if (orgUnitIds.length === 0) return Promise.resolve(orgUnitsToRender());
+
+            return getOrgUnits(orgUnitIds).then(orgUnitNames => {
+                this.orgUnits = this.orgUnits.map(ou => {
+                    const ouPath = ou.orgUnitPath.split("/");
+                    const ouPathNames = ouPath
+                        .map(id => {
+                            const orgUnit = orgUnitNames.organisationUnits.find(ou => ou.id === id);
+                            return orgUnit ? orgUnit.shortName : id;
+                        })
+                        .join("/");
+
+                    return { ...ou, orgUnitPath: ouPathNames };
+                });
+
+                return orgUnitsToRender();
+            });
+        }
+    }
+
+    loadSubnationalValues() {
+        const $nextPageButton = document.querySelector(`.pagination-next-${this.tableConatinerId}`);
+
+        if ($nextPageButton) {
+            $nextPageButton.addEventListener("click", e => {
+                if (e.target.classList.contains("no-pag")) return;
+
+                this.loadSubnationalValues(this.subnationalDataSetId);
+            });
+        }
+
+        const $previousPageButton = document.querySelector(
+            `.pagination-pre-${this.tableConatinerId}`
+        );
+
+        if ($previousPageButton) {
+            $previousPageButton.addEventListener("click", e => {
+                if (e.target.classList.contains("no-pag")) return;
+
+                this.loadSubnationalValues(this.subnationalDataSetId);
+            });
+        }
+
+        const periodId = $("#selectedPeriodId").val();
+
+        const params = {
+            period: periodId,
+            dataSet: this.subnationalDataSetId,
+            orgUnit: selectedOrgUnitId,
+            children: true,
+        };
+
+        $.ajax({
+            url: "../api/dataValueSets",
+            data: params,
+            dataType: "json",
+            success: json => {
+                $.safeEach(json.dataValues, (i, dataValue) => {
+                    const fieldId = `#${dataValue.orgUnit}-${dataValue.dataElement}-${dataValue.categoryOptionCombo}-val`;
+                    if ($(fieldId).length > 0) {
+                        const entryField = $(fieldId);
+                        if ("true" == dataValue.value && entryField.attr("type") == "checkbox") {
+                            $(fieldId).prop("checked", true);
+                        } else {
+                            $(fieldId).val(dataValue.value);
+                        }
+                    }
+                });
+
+                this.$tabContainer.find("#subnational input[type=text]").on("change", e => {
+                    this.onSubnationalInputChange(e.target.id);
+                });
+                this.$tabContainer.find("#subnational textarea").on("change", e => {
+                    this.onSubnationalTextAreaChange(e.target.id);
+                });
+
+                this.updateSubnationalDataElementTotals();
+            },
+            error: function(xhr) {
+                console.log("Error in the request");
+                console.log(xhr);
+            },
+        });
+    }
+
+    isValidUid(value) {
+        const UID_PATTERN = /^[a-zA-Z]{1}[a-zA-Z0-9]{10}$/;
+
+        return UID_PATTERN.test(value);
+    }
+
+    onLoadingPage(page) {
+        return this.renamePageOrgUnitPaths(page);
+    }
+
+    onLoadedPage() {
+        this.loadSubnationalValues(this.subnationalDataSetId);
+    }
+
+    render() {
+        this.$tabContainer.find("#subnational .cde table tbody").empty();
+        this.$tabContainer.find("#custom-form-loader").show();
+
+        const filter = `paging=false&var=dataSet:${this.subnationalDataSetId}&var=orgUnit:${dhis2.de.currentOrganisationUnitId}`;
+
+        $.ajax({
+            url: `../api/sqlViews/F9WNm3XNjli/data?${filter}`,
+            type: "get",
+            success: response => {
+                this.orgUnits = response.listGrid.rows.map(row => ({
+                    orgUnitId: row[0],
+                    orgUnitName: row[1],
+                    orgUnitPath: row[2],
+                }));
+
+                if (this.orgUnits.length > 0) {
+                    //TODO: move this to custom form
+                    const tableOptions = {
+                        data: this.orgUnits,
+                        pagination: this.pageSize,
+                        tableDiv: `#${this.tableConatinerId}`,
+                        templateID: `${this.subnationalDataSetId}_template`,
+                        onLoadingPage: page => this.onLoadingPage(page),
+                        onLoadedPage: () => this.onLoadedPage(),
+                    };
+
+                    const sheetsee = new Sheetsee();
+
+                    sheetsee.makeTable(tableOptions);
+
+                    this.$tabContainer.find("#custom-form-loader").hide();
+                } else {
+                    const tabId = this.$tabContainer.attr("id");
+                    $(`a[href="#${tabId}"]`)
+                        .closest("li")
+                        .hide();
+                }
+            },
+            error: function(xhr) {
+                console.log("Error in the request");
+                console.log(xhr);
+            },
+        });
+    }
 }

--- a/HEP-data-entry/src/components/snakebite/resources/subnational-tab.js
+++ b/HEP-data-entry/src/components/snakebite/resources/subnational-tab.js
@@ -165,7 +165,7 @@ class SubnationalTab {
         this.$tabContainer.find("#custom-form-loader").show();
 
         const filter = `paging=false&var=dataSet:${this.subnationalDataSetId}&var=orgUnit:${dhis2.de.currentOrganisationUnitId}`;
-
+        const tabId = this.$tabContainer.attr("id");
         $.ajax({
             url: `../api/sqlViews/F9WNm3XNjli/data?${filter}`,
             type: "get",
@@ -177,6 +177,9 @@ class SubnationalTab {
                 }));
 
                 if (this.orgUnits.length > 0) {
+                    $(`a[href="#${tabId}"]`)
+                        .closest("li")
+                        .show();
                     //TODO: move this to custom form
                     const tableOptions = {
                         data: this.orgUnits,

--- a/HEP-data-entry/src/data/snakebite/repositories/D2CustomMetadataRepository.ts
+++ b/HEP-data-entry/src/data/snakebite/repositories/D2CustomMetadataRepository.ts
@@ -14,8 +14,12 @@ export class D2CustomMetadataRepository implements CustomMetadataRepository {
             throw new Error(`Does not exist a required ${this.dataStoreClient.namespace} namespace with a ${key} key in the data store`);
         }
 
-        if (!customMetadata.subnationalDataSet) {
-            throw new Error(`Does not exist a required prop subnationalDataSet in ${this.dataStoreClient.namespace} namespace and ${key} key in the data store`);
+        if (!customMetadata.subnationalEpidemiologicalDataDataSet) {
+            throw new Error(`Does not exist a required prop subnationalEpidemiologicalDataDataSet in ${this.dataStoreClient.namespace} namespace and ${key} key in the data store`);
+        }
+
+        if (!customMetadata.subnationalStockDataDataSet) {
+            throw new Error(`Does not exist a required prop subnationalStockDataDataSet in ${this.dataStoreClient.namespace} namespace and ${key} key in the data store`);
         }
 
         return customMetadata;

--- a/HEP-data-entry/src/domain/snakebite/CustomMetadata.ts
+++ b/HEP-data-entry/src/domain/snakebite/CustomMetadata.ts
@@ -17,8 +17,14 @@ interface OptionComboData {
     order?: number;
 }
 
+interface SubnationalDataSet {
+    id: string,
+    name: string
+}
+
 export interface CustomMetadata {
-    subnationalDataSet: string,
     dataElements: Record<string, DataElementData>;
     optionCombos: Record<string, OptionComboData>;
+    subnationalStockDataDataSet: SubnationalDataSet;
+    subnationalEpidemiologicalDataDataSet: SubnationalDataSet
 }

--- a/HEP-data-entry/src/factories/CustomFormFactories.ts
+++ b/HEP-data-entry/src/factories/CustomFormFactories.ts
@@ -30,9 +30,10 @@ export class SnakeBiteCustomFormFactory implements CustomFormFactory {
     async createCustomForm(dataSet: DataSet): Promise<string> {
         const customMetadata = await this.customMetadataRepository.get();
 
-        const subnationalDataSet = await this.dataSetRepository.get(customMetadata.subnationalDataSet);
+        const subnationalStockDataDataSet = await this.dataSetRepository.get(customMetadata.subnationalStockDataDataSet.id);
+        const subnationalEpidemiologicalDataDataSet = await this.dataSetRepository.get(customMetadata.subnationalEpidemiologicalDataDataSet.id);
         const antivenomEntries = await this.antivenomEntriesRepository.get()
 
-        return await SnakeBiteCustomForm(dataSet, subnationalDataSet, customMetadata, antivenomEntries)
+        return await SnakeBiteCustomForm(dataSet, subnationalStockDataDataSet, subnationalEpidemiologicalDataDataSet, customMetadata, antivenomEntries)
     }
 }


### PR DESCRIPTION
### :pushpin: References
https://app.clickup.com/t/buyh6f
### :memo: Implementation

#### Subnational
- [x] Split into 3 tabs: one for "National", one for "Subnational epidemiological data" with the cases, and another one for "Subnational stock data" with the products (Jorge)
- [x] Apply DE showName feature to subnational tabs

### :art: Screenshots


### :fire: Is there anything the reviewer should know to test it?
#### Metadata changes

**Remember to assign orgunits for subnational data sets, if a subnational data set is not assigned to any org unit the tab will be  hidden**

#### Data Store

* CustomMetadata key changes:
Remove subnationalDataSet prop

```
"subnationalDataSet":  "SAV16xEdCZW"
```
add two new props **subnationalStockDataDataSet** and **subnationalEpidemiologicalDataDataSet**

```js
  "subnationalStockDataDataSet": {
    "id": "SAV16xEdCZW",
    "name": "Subnational Stock Data"
  },
  "subnationalEpidemiologicalDataDataSet": {
    "id": "WHPEpoVDFFv",
    "name": "Subnational Epidemiological Data"
  }
```

* AntivenomEntries changes:


#### To generate the custom form
```
cd /HEP-data-entry
yarn build
node lib/cli.js --url='http://user:pwd!@dhisUrl' --dataset-id='XBgvNrxpcDC' --module='snakebite'
```

**Important**: the command uploads all data set to the server. 
**Important**: Sometimes to generate the custom form, age category options are duplicated in data elements. I think this is an API bug.

### :bookmark_tabs: Others


