### PR TITLE
Implement select all in table header

### DIFF
--- a/HWF/Reports/NHWA Module 1 Fix totals by activity level.html
+++ b/HWF/Reports/NHWA Module 1 Fix totals by activity level.html
@@ -98,16 +98,24 @@
         background-color: #f3f3f3;
         font-weight: bold;
     }
+
+    table.dataTable tr th.select-checkbox.selected::after {
+        content: "✔";
+        margin-top: -11px;
+        margin-left: -4px;
+        text-align: center;
+        text-shadow: rgb(176, 190, 217) 1px 1px, rgb(176, 190, 217) -1px -1px, rgb(176, 190, 217) 1px -1px, rgb(176, 190, 217) -1px 1px;
+    }
 </style>
 <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.css" />
 <link rel="stylesheet" href="https://cdn.datatables.net/rowgroup/1.1.0/css/rowGroup.dataTables.min.css" />
 <link rel="stylesheet" href="https://cdn.datatables.net/buttons/1.6.0/css/buttons.dataTables.min.css" />
-<link rel="stylesheet" href="https://cdn.datatables.net/select/1.3.1/css/select.dataTables.min.css" />
+<link rel="stylesheet" href="https://cdn.datatables.net/select/1.2.1/css/select.dataTables.min.css" />
 <script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
 <script src="https://cdn.datatables.net/rowgroup/1.1.0/js/dataTables.rowGroup.min.js"></script>
 <script src="https://cdn.datatables.net/buttons/1.6.0/js/dataTables.buttons.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js"></script>
-<script src="https://cdn.datatables.net/select/1.3.1/js/dataTables.select.min.js"></script>
+<script src="https://cdn.datatables.net/select/1.2.1/js/dataTables.select.min.js"></script>
 <script type="text/javascript">
 
     var missingTotalsRows = [];
@@ -752,6 +760,26 @@
                         }
                     }
                 ]
+            }
+        });
+
+        module1TotalsTable.on("click", "th.select-checkbox", function () {
+            debugger;
+            if ($("th.select-checkbox").hasClass("selected")) {
+                module1TotalsTable.rows().deselect();
+                $("th.select-checkbox").removeClass("selected");
+            } else {
+                module1TotalsTable.rows().select();
+                $("th.select-checkbox").addClass("selected");
+            }
+        }).on("select deselect", function () {
+            ("Some selection or deselection going on")
+            if (module1TotalsTable.rows({
+                selected: true
+            }).count() !== module1TotalsTable.rows().count()) {
+                $("th.select-checkbox").removeClass("selected");
+            } else {
+                $("th.select-checkbox").addClass("selected");
             }
         });
 


### PR DESCRIPTION
### :pushpin: References
https://app.clickup.com/t/f7614a
### :memo: Implementation

- [x] Implement select all in the table header
I have downgraded the `dataTable.select` plugin to make select all check box functionality work.

### :art: Screenshots

<img width="1430" alt="Captura de pantalla 2021-03-09 a las 9 39 45" src="https://user-images.githubusercontent.com/5593590/110443073-d3779000-80bb-11eb-80f1-9dc7e97f75af.png">

### :fire: Is there anything the reviewer should know to test it?
### :bookmark_tabs: Others
