### PR TITLE
Mark auto calculated totals as readonly

### DIFF
--- a/HEP-data-entry/src/components/snakebite/CatOptionCombosDataCells.tsx
+++ b/HEP-data-entry/src/components/snakebite/CatOptionCombosDataCells.tsx
@@ -33,7 +33,7 @@ export function CatOptionCombosDataCells(attributes: EntryFieldAttributes): stri
                     name={orgUnitDataElementAtt ? "subnationalTotal" : "total"}
                     readonly="readonly"
                     title={`${dataElement.code}`}
-                    class={"entryfield"}
+                    class={"entryfield read-only"}
                     type={"text"}
                 />
             </td>

--- a/HEP-data-entry/src/components/snakebite/resources/custom-form.js
+++ b/HEP-data-entry/src/components/snakebite/resources/custom-form.js
@@ -12,6 +12,10 @@ $(document).ready(function() {
         selectedOrgUnitId = dhis2.de.currentOrganisationUnitId;
         $("#tabs").tabs({ active: 0 });
 
+        $(".read-only").each(function() {
+            $(this).prop("readonly", true);
+        });
+
         const subnationalTabs = [];
 
         $(".subnational-tab").each(function() {


### PR DESCRIPTION
### :pushpin: References
https://app.clickup.com/t/fv32dp
### :memo: Implementation

- [x] Make auto calculated totals readonly

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?
#### To generate the custom form
```
cd /HEP-data-entry
yarn build
node lib/cli.js --url='http://user:pwd!@dhisUrl' --dataset-id='XBgvNrxpcDC' --module='snakebite'
```
### :bookmark_tabs: Others
