### PR TITLE
Fix/bug module 1 subnational single entry when pagination non exist

### DIFF
--- a/HEP-data-entry/src/components/module1_subnational_single/dataElementGroups.ts
+++ b/HEP-data-entry/src/components/module1_subnational_single/dataElementGroups.ts
@@ -109,8 +109,8 @@ export const dataElementGroups: DataElementGroup[] = [
     {
         order: '5',
         inputNumeric: {
-            id: 'UPfQopzBdyx-Xr12mI7VPn3-val',
-            displayName: 'Dental Assistants and Therapists'
+            id: 'lHfsZY4fyv4-Xr12mI7VPn3-val',
+            displayName: 'Pharmacists'
         }
     }
 ]

--- a/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.js
+++ b/HEP-data-entry/src/components/module1_subnational_single/resources/custom-form.js
@@ -110,17 +110,25 @@ function loadValues() {
         $(this).attr("disabled", "disabled");
     });
 
-    document.querySelector(".pagination-next-orgUnitsTable").addEventListener("click", function(e) {
-        if (e.target.classList.contains("no-pag")) return;
+    const $nextPageButton = document.querySelector(".pagination-next-orgUnitsTable");
 
-        loadValues();
-    });
+    if ($nextPageButton) {
+        $nextPageButton.addEventListener("click", function(e) {
+            if (e.target.classList.contains("no-pag")) return;
 
-    document.querySelector(".pagination-pre-orgUnitsTable").addEventListener("click", function(e) {
-        if (e.target.classList.contains("no-pag")) return;
+            loadValues();
+        });
+    }
 
-        loadValues();
-    });
+    const $previousPageButton = document.querySelector(".pagination-pre-orgUnitsTable");
+
+    if ($previousPageButton) {
+        $previousPageButton.addEventListener("click", function(e) {
+            if (e.target.classList.contains("no-pag")) return;
+
+            loadValues();
+        });
+    }
 
     var periodId = $("#selectedPeriodId").val();
 


### PR DESCRIPTION
### :pushpin: References
https://app.clickup.com/t/fq5vda
### :memo: Implementation

1) Last occupation listed as 'Dental Assistants and Therapists' is wrong. It should be 'Pharmacists'. This is number 7 in Module 1 data entry form.
2) I cannot see the old subnational data entry form to cross check if data enetered through single entry is appearing in the subnational dataset.
3) auto calculate not functioning in data entry form.
4) The data entered is not saved.
5) OU name change proposed in data entry form does not appear in the reports
Points 2,3,4,5 were working in the last version I tested

- [x] Fix bug when there is not pagination (solve 2,3,4,5)
- [x] Replace Dental Assistants and Therapists (UPfQopzBdyx) DE to Pharmacists (lHfsZY4fyv4)

### :art: Screenshots

### :fire: Is there anything the reviewer should know to test it?
having a local copy of WHO DEV instance
```
cd HEP-data-entry
yarn build
node lib/cli.js --url='http://user:pwd@localhost:8080'  --dataset-id='cLeSS7eAxN0' --module='module1_subnational_single_entry'
```
Then test it locally and finally export the custom form and dataset and import it in the destination instance

### :bookmark_tabs: Others
