### PR TITLE
Added feature to remove all the calculated zeros without 0's childern

### DIFF
--- a/HWF/Reports/NHWA Auto-complete compute.html
+++ b/HWF/Reports/NHWA Auto-complete compute.html
@@ -63,8 +63,8 @@
             type="text/css"
         />
         <style type="text/css">
-		#mainPage {
-				margin: 5px 10px 10px 20px!important;
+            #mainPage {
+                margin: 5px 10px 10px 20px !important;
             }
         </style>
         <style>
@@ -421,7 +421,6 @@
     </head>
 
     <body>
-
         <div class="page" id="mainPage">
             <script type="text/javascript">
                 dhis2.util.namespace("dhis2.report");
@@ -493,68 +492,64 @@
                             var deleted = 0;
                             const pagesize = 500;
                             var getAllObjects = function (removeDataValues) {
-                                var start = 0,
-                                    totalObjects = removeDataValues.length,
-                                    pushedObjects = 0,
-                                    chunkSize = pagesize,
-                                    dfd = $.Deferred(),
-                                    getChunk = function (start, chunkSize, pushedObjects, deleted) {
-                                        return $.ajax({
-                                            url: ".." + "/api/dataValueSets?importStrategy=DELETE",
-                                            type: "POST",
-                                            dataType: "json",
-                                            data: JSON.stringify({
-                                                dataElementIdScheme: "UID",
-                                                dataValues: removeDataValues.slice(
-                                                    start,
-                                                    chunkSize
-                                                ),
-                                                idScheme: "UID",
-                                                orgUnitIdScheme: "UID",
-                                            }),
-                                            xhrFields: {
-                                                withCredentials: true,
-                                            },
-                                            crossDomain: false,
-                                            contentType: "application/json; charset=utf-8",
-                                            success: function (response) {
-                                                console.log(response);
-                                                return response;
-                                            },
-                                            error: function (e) {
-                                                console.log(e);
-                                                return e;
-                                            },
-                                        });
-                                    },
-                                    recursiveGet = function () {
-                                        getChunk(start, chunkSize, pushedObjects, deleted).done(
-                                            function (retVal) {
-                                                console.log(retVal);
-                                                if (retVal.status !== "ERROR") {
-                                                    pushedObjects += pagesize;
-                                                    if (
-                                                        retVal.importCount &&
-                                                        retVal.importCount.deleted
-                                                    ) {
-                                                        deleted =
-                                                            deleted + retVal.importCount.deleted;
-                                                    }
-                                                    if (totalObjects > pushedObjects) {
-                                                        start = start + pagesize;
-                                                        chunkSize = chunkSize + pagesize;
-                                                        recursiveGet();
-                                                    } else {
-                                                        console.log("finished: " + deleted);
-                                                        dfd.resolve();
-                                                    }
+                                var start = 0;
+                                var totalObjects = removeDataValues.length;
+                                var pushedObjects = 0;
+                                var chunkSize = pagesize;
+                                var dfd = $.Deferred();
+                                var getChunk = function (start, chunkSize, pushedObjects, deleted) {
+                                    return $.ajax({
+                                        url: "../api/dataValueSets?importStrategy=DELETE",
+                                        type: "POST",
+                                        dataType: "json",
+                                        data: JSON.stringify({
+                                            dataElementIdScheme: "UID",
+                                            dataValues: removeDataValues.slice(start, chunkSize),
+                                            idScheme: "UID",
+                                            orgUnitIdScheme: "UID",
+                                        }),
+                                        xhrFields: {
+                                            withCredentials: true,
+                                        },
+                                        crossDomain: false,
+                                        contentType: "application/json; charset=utf-8",
+                                        success: function (response) {
+                                            console.log(response);
+                                            return response;
+                                        },
+                                        error: function (e) {
+                                            console.log(e);
+                                            return e;
+                                        },
+                                    });
+                                };
+                                var recursiveGet = function () {
+                                    getChunk(start, chunkSize, pushedObjects, deleted).done(
+                                        function (retVal) {
+                                            console.log(retVal);
+                                            if (retVal.status !== "ERROR") {
+                                                pushedObjects += pagesize;
+                                                if (
+                                                    retVal.importCount &&
+                                                    retVal.importCount.deleted
+                                                ) {
+                                                    deleted = deleted + retVal.importCount.deleted;
+                                                }
+                                                if (totalObjects > pushedObjects) {
+                                                    start = start + pagesize;
+                                                    chunkSize = chunkSize + pagesize;
+                                                    recursiveGet();
                                                 } else {
-                                                    console.log("error: " + deleted);
+                                                    console.log("finished: " + deleted);
                                                     dfd.resolve();
                                                 }
+                                            } else {
+                                                console.log("error: " + deleted);
+                                                dfd.resolve();
                                             }
-                                        );
-                                    };
+                                        }
+                                    );
+                                };
                                 recursiveGet();
                                 return dfd;
                             };

--- a/HWF/Reports/NHWA Auto-complete compute.html
+++ b/HWF/Reports/NHWA Auto-complete compute.html
@@ -526,7 +526,7 @@
                                         return deferred.promise();
                                     };
 
-                                    const items = _.chunk(update, 5000);
+                                    const items = _.chunk(update, 500);
                                     let looper = $.Deferred().resolve();
 
                                     return $.when.apply(

--- a/HWF/Reports/NHWA Auto-complete compute.html
+++ b/HWF/Reports/NHWA Auto-complete compute.html
@@ -526,7 +526,7 @@
                                         return deferred.promise();
                                     };
 
-                                    const items = _.chunk(update, 500);
+                                    const items = _.chunk(update, 5000);
                                     let looper = $.Deferred().resolve();
 
                                     return $.when.apply(

--- a/HWF/Reports/NHWA Auto-complete compute.html
+++ b/HWF/Reports/NHWA Auto-complete compute.html
@@ -525,75 +525,82 @@
                         <script type="text/javascript">
                             var correctDataValues = undefined;
                             var removeDataValues = undefined;
-							var deleted = 0;
-							const pagesize=500;
-														var getAllObjects = function (removeDataValues) {
-														var start = 0,
-														totalObjects = removeDataValues.length,
-														pushedObjects = 0,
-														chunkSize = pagesize,
-														dfd = $.Deferred(),
-														getChunk = function (start, chunkSize, pushedObjects, deleted) {
-														return $.ajax({
-                                                            url: ".." + "/api/dataValueSets?importStrategy=DELETE",
-															type: 'POST',
-															dataType: 'json',
-															data: JSON.stringify({
-																		dataElementIdScheme: "UID",
-																		dataValues: removeDataValues.slice(start, chunkSize),
-																		idScheme: "UID",
-																		orgUnitIdScheme: "UID",
-																	}),
-															xhrFields: {
-																		withCredentials: true,
-																	},
-															crossDomain: false,
-															contentType: 'application/json; charset=utf-8',
-															success: function (response){
-																		console.log(response);
-																		return response;
-																		},
-															error: function (e){
-															console.log(e);
-															return e;
-															}
-														});
-														},
-														recursiveGet = function () {
-															getChunk(start, chunkSize, pushedObjects, deleted).done(function (retVal) {
-																console.log(retVal);
-																if (retVal.status !== 'ERROR') {
-																		pushedObjects += pagesize;
-																		if (retVal.importCount && retVal.importCount.deleted){
-																			deleted = deleted + retVal.importCount.deleted;
-																		}
-																	if (totalObjects > pushedObjects) {
-																		start = start + pagesize;
-																		chunkSize = chunkSize + pagesize;
-																		recursiveGet();
-																	}
-																	else {
-																	console.log("finished: "+deleted);
-																		dfd.resolve();
-																	}
-																}
-																else {
-																	console.log("error: "+deleted);
-																	dfd.resolve();
-																}
-															});
-														};
-														recursiveGet();
-														return dfd;
-													};
+                            var deleted = 0;
+                            const pagesize = 500;
+                            var getAllObjects = function (removeDataValues) {
+                                var start = 0,
+                                    totalObjects = removeDataValues.length,
+                                    pushedObjects = 0,
+                                    chunkSize = pagesize,
+                                    dfd = $.Deferred(),
+                                    getChunk = function (start, chunkSize, pushedObjects, deleted) {
+                                        return $.ajax({
+                                            url: ".." + "/api/dataValueSets?importStrategy=DELETE",
+                                            type: "POST",
+                                            dataType: "json",
+                                            data: JSON.stringify({
+                                                dataElementIdScheme: "UID",
+                                                dataValues: removeDataValues.slice(
+                                                    start,
+                                                    chunkSize
+                                                ),
+                                                idScheme: "UID",
+                                                orgUnitIdScheme: "UID",
+                                            }),
+                                            xhrFields: {
+                                                withCredentials: true,
+                                            },
+                                            crossDomain: false,
+                                            contentType: "application/json; charset=utf-8",
+                                            success: function (response) {
+                                                console.log(response);
+                                                return response;
+                                            },
+                                            error: function (e) {
+                                                console.log(e);
+                                                return e;
+                                            },
+                                        });
+                                    },
+                                    recursiveGet = function () {
+                                        getChunk(start, chunkSize, pushedObjects, deleted).done(
+                                            function (retVal) {
+                                                console.log(retVal);
+                                                if (retVal.status !== "ERROR") {
+                                                    pushedObjects += pagesize;
+                                                    if (
+                                                        retVal.importCount &&
+                                                        retVal.importCount.deleted
+                                                    ) {
+                                                        deleted =
+                                                            deleted + retVal.importCount.deleted;
+                                                    }
+                                                    if (totalObjects > pushedObjects) {
+                                                        start = start + pagesize;
+                                                        chunkSize = chunkSize + pagesize;
+                                                        recursiveGet();
+                                                    } else {
+                                                        console.log("finished: " + deleted);
+                                                        dfd.resolve();
+                                                    }
+                                                } else {
+                                                    console.log("error: " + deleted);
+                                                    dfd.resolve();
+                                                }
+                                            }
+                                        );
+                                    };
+                                recursiveGet();
+                                return dfd;
+                            };
                             $(document).ready(function () {
                                 const isDevelopment = false;
                                 const baseUrl = isDevelopment
                                     ? "http://taris.sferadev.com:9004"
                                     : "..";
 
-                                // Build "totals that do not match" table 
-								const calculatedNumericCells = [
+                                // Build "totals that do not match" table
+                                const calculatedNumericCells = [
                                     //Working Details
 
                                     //1 - Medical Doctors
@@ -1547,60 +1554,70 @@
                                             {
                                                 text: "Fix all incorrect values",
                                                 action: function (e, dt, node, config) {
-												if(removeDataValues !==undefined){
-												
-                                                $("#loading").show();
-												this.disable();
-												var removevaluescount = removeDataValues.length;
-															getAllObjects(removeDataValues).then(function () { 
-															if (correctDataValues !== undefined) {
-																	
-																$.ajax({
-																	type: "POST",
-																	url: baseUrl + "/api/dataValueSets",
-																	dataType: "json",
-																	headers: {
-																		Accept: "application/json",
-																		"Content-Type": "application/json",
-																	},
-																	data: JSON.stringify({
-																		dataElementIdScheme: "UID",
-																		dataValues: correctDataValues,
-																		idScheme: "UID",
-																		orgUnitIdScheme: "UID",
-																	}),
-																	xhrFields: {
-																		withCredentials: true,
-																	},
-																	crossDomain: isDevelopment,
-																	success: function (response) {
-																		console.log(response);
-																		alert(
-																			`Status: ${response.status}\n` +
-																				`Overview: ${response.description}\n` +
-																				`Import count: ${response.importCount.imported} imported, ${response.importCount.updated} updated, ${response.importCount.ignored} ignored and  ${deleted} deleted` +
-																				`\n${
-																					response.conflicts
-																						? response.conflicts.map(
-																							  e =>
-																								  "CONFLICT: " +
-																								  e.value +
-																								  "\n"
-																						  )
-																						: ""
-																				}`
-																		);
-																		$("#loading").hide();
-																		location.reload();
-																	},
-																});
-																this.disable();
-															}else{
-																		alert("Removed:  0's values" );
-																		this.disable();
-															}							
-															});
-                                                    } else if (correctDataValues !== undefined){
+                                                    if (removeDataValues !== undefined) {
+                                                        $("#loading").show();
+                                                        this.disable();
+                                                        var removevaluescount =
+                                                            removeDataValues.length;
+                                                        getAllObjects(removeDataValues).then(
+                                                            function () {
+                                                                if (
+                                                                    correctDataValues !== undefined
+                                                                ) {
+                                                                    $.ajax({
+                                                                        type: "POST",
+                                                                        url:
+                                                                            baseUrl +
+                                                                            "/api/dataValueSets",
+                                                                        dataType: "json",
+                                                                        headers: {
+                                                                            Accept: "application/json",
+                                                                            "Content-Type":
+                                                                                "application/json",
+                                                                        },
+                                                                        data: JSON.stringify({
+                                                                            dataElementIdScheme:
+                                                                                "UID",
+                                                                            dataValues:
+                                                                                correctDataValues,
+                                                                            idScheme: "UID",
+                                                                            orgUnitIdScheme: "UID",
+                                                                        }),
+                                                                        xhrFields: {
+                                                                            withCredentials: true,
+                                                                        },
+                                                                        crossDomain: isDevelopment,
+                                                                        success: function (
+                                                                            response
+                                                                        ) {
+                                                                            console.log(response);
+                                                                            alert(
+                                                                                `Status: ${response.status}\n` +
+                                                                                    `Overview: ${response.description}\n` +
+                                                                                    `Import count: ${response.importCount.imported} imported, ${response.importCount.updated} updated, ${response.importCount.ignored} ignored and  ${deleted} deleted` +
+                                                                                    `\n${
+                                                                                        response.conflicts
+                                                                                            ? response.conflicts.map(
+                                                                                                  e =>
+                                                                                                      "CONFLICT: " +
+                                                                                                      e.value +
+                                                                                                      "\n"
+                                                                                              )
+                                                                                            : ""
+                                                                                    }`
+                                                                            );
+                                                                            $("#loading").hide();
+                                                                            location.reload();
+                                                                        },
+                                                                    });
+                                                                    this.disable();
+                                                                } else {
+                                                                    alert("Removed:  0's values");
+                                                                    this.disable();
+                                                                }
+                                                            }
+                                                        );
+                                                    } else if (correctDataValues !== undefined) {
                                                         $.ajax({
                                                             type: "POST",
                                                             url: baseUrl + "/api/dataValueSets",
@@ -1641,8 +1658,7 @@
                                                             },
                                                         });
                                                         this.disable();
-													}
-													else {
+                                                    } else {
                                                         alert("Still loading data, please wait!");
                                                     }
                                                 },
@@ -1674,7 +1690,8 @@
                                             url:
                                                 baseUrl +
                                                 //"/api/dataValueSets.json?dataSet=Tu81BTLUuCT&startDate=2010-01-01&endDate=2021-01-01&orgUnit=zFInPJBZVbN",
-                                                "/api/dataValueSets.json?dataSet=Tu81BTLUuCT&startDate=1970-01-01&endDate=2100-01-01&orgUnit=" + orgUnits,
+                                                "/api/dataValueSets.json?dataSet=Tu81BTLUuCT&startDate=1970-01-01&endDate=2100-01-01&orgUnit=" +
+                                                orgUnits,
                                             xhrFields: {
                                                 withCredentials: true,
                                             },
@@ -1768,7 +1785,9 @@
                                                                     )
                                                                 )
                                                                 .value();
-                                                            const result_remove = _(_.keys(providedValues))
+                                                            const result_remove = _(
+                                                                _.keys(providedValues)
+                                                            )
                                                                 .union(_.keys(calculatedValues))
                                                                 .map(period => {
                                                                     const calculatedValue =
@@ -1782,14 +1801,21 @@
                                                                               ]
                                                                             : undefined;
 
-                                                                    var providedValue =""
-																	if  (!isNaN(
+                                                                    var providedValue = "";
+                                                                    if (
+                                                                        !isNaN(
                                                                             providedValues[period]
-                                                                        )){
-																		providedValue = providedValues[period];
-																		}
+                                                                        )
+                                                                    ) {
+                                                                        providedValue =
+                                                                            providedValues[period];
+                                                                    }
 
-                                                                    if (calculatedValue === undefined && providedValue === 0  ) {
+                                                                    if (
+                                                                        calculatedValue ===
+                                                                            undefined &&
+                                                                        providedValue === 0
+                                                                    ) {
                                                                         return {
                                                                             dataElement:
                                                                                 total.id.split(
@@ -1806,8 +1832,7 @@
                                                                                 period.split(
                                                                                     "-"
                                                                                 )[1],
-                                                                            value:
-                                                                                0,
+                                                                            value: 0,
                                                                             originalValue:
                                                                                 providedValue,
                                                                             sum: total.children
@@ -1903,7 +1928,6 @@
                                                                               ]
                                                                             : undefined;
 
-
                                                                     const providedValue =
                                                                         !isNaN(
                                                                             providedValues[period]
@@ -1983,19 +2007,21 @@
 
                                                     correctDataValues = result;
                                                     removeDataValues = result_remove;
-													if ( result_remove.length > 0 ){
-													result_remove.forEach(function (element) {
-                                                        module1TotalsTable.row.add([
-                                                            metadata[element.dataElement],
-                                                            metadata[element.categoryOptionCombo],
-                                                            element.period,
-                                                            metadata[element.orgUnit],
-                                                            `${element.sum} = ${element.value}`,
-															element.originalValue + "",
-                                                        ]);
-                                                    });
-													}
-													result.forEach(function (element) {
+                                                    if (result_remove.length > 0) {
+                                                        result_remove.forEach(function (element) {
+                                                            module1TotalsTable.row.add([
+                                                                metadata[element.dataElement],
+                                                                metadata[
+                                                                    element.categoryOptionCombo
+                                                                ],
+                                                                element.period,
+                                                                metadata[element.orgUnit],
+                                                                `${element.sum} = ${element.value}`,
+                                                                element.originalValue + "",
+                                                            ]);
+                                                        });
+                                                    }
+                                                    result.forEach(function (element) {
                                                         module1TotalsTable.row.add([
                                                             metadata[element.dataElement],
                                                             metadata[element.categoryOptionCombo],

--- a/HWF/Reports/NHWA Auto-complete compute.html
+++ b/HWF/Reports/NHWA Auto-complete compute.html
@@ -489,75 +489,57 @@
                         <script type="text/javascript">
                             var correctDataValues = undefined;
                             var removeDataValues = undefined;
-                            var deleted = 0;
-                            const pagesize = 500;
-                            var getAllObjects = function (removeDataValues) {
-                                var start = 0;
-                                var totalObjects = removeDataValues.length;
-                                var pushedObjects = 0;
-                                var chunkSize = pagesize;
-                                var dfd = $.Deferred();
-                                var getChunk = function (start, chunkSize, pushedObjects, deleted) {
-                                    return $.ajax({
-                                        url: "../api/dataValueSets?importStrategy=DELETE",
-                                        type: "POST",
-                                        dataType: "json",
-                                        data: JSON.stringify({
-                                            dataElementIdScheme: "UID",
-                                            dataValues: removeDataValues.slice(start, chunkSize),
-                                            idScheme: "UID",
-                                            orgUnitIdScheme: "UID",
-                                        }),
-                                        xhrFields: {
-                                            withCredentials: true,
-                                        },
-                                        crossDomain: false,
-                                        contentType: "application/json; charset=utf-8",
-                                        success: function (response) {
-                                            console.log(response);
-                                            return response;
-                                        },
-                                        error: function (e) {
-                                            console.log(e);
-                                            return e;
-                                        },
-                                    });
-                                };
-                                var recursiveGet = function () {
-                                    getChunk(start, chunkSize, pushedObjects, deleted).done(
-                                        function (retVal) {
-                                            console.log(retVal);
-                                            if (retVal.status !== "ERROR") {
-                                                pushedObjects += pagesize;
-                                                if (
-                                                    retVal.importCount &&
-                                                    retVal.importCount.deleted
-                                                ) {
-                                                    deleted = deleted + retVal.importCount.deleted;
-                                                }
-                                                if (totalObjects > pushedObjects) {
-                                                    start = start + pagesize;
-                                                    chunkSize = chunkSize + pagesize;
-                                                    recursiveGet();
-                                                } else {
-                                                    console.log("finished: " + deleted);
-                                                    dfd.resolve();
-                                                }
-                                            } else {
-                                                console.log("error: " + deleted);
-                                                dfd.resolve();
-                                            }
-                                        }
+
+                            $(document).ready(function () {
+                                const baseUrl = "..";
+
+                                const updateDataValues = function (
+                                    update,
+                                    strategy = "CREATE_AND_UPDATE"
+                                ) {
+                                    const request = dataValues => {
+                                        const deferred = $.Deferred();
+
+                                        $.ajax({
+                                            type: "POST",
+                                            url: `${baseUrl}/api/dataValueSets?importStrategy=${strategy}`,
+                                            dataType: "json",
+                                            headers: {
+                                                Accept: "application/json",
+                                                "Content-Type": "application/json",
+                                            },
+                                            data: JSON.stringify({
+                                                dataValues,
+                                                dataElementIdScheme: "UID",
+                                                idScheme: "UID",
+                                                orgUnitIdScheme: "UID",
+                                            }),
+                                            xhrFields: { withCredentials: true },
+                                            success: function (data) {
+                                                deferred.resolve(data);
+                                            },
+                                            error: function (error) {
+                                                deferred.reject(error);
+                                            },
+                                        });
+
+                                        return deferred.promise();
+                                    };
+
+                                    const items = _.chunk(update, 5000);
+                                    let looper = $.Deferred().resolve();
+
+                                    return $.when.apply(
+                                        $,
+                                        $.map(items, function (dataValues, i) {
+                                            looper = looper.then(function () {
+                                                return request(dataValues);
+                                            });
+
+                                            return looper;
+                                        })
                                     );
                                 };
-                                recursiveGet();
-                                return dfd;
-                            };
-                            $(document).ready(function () {
-                                const isDevelopment = false;
-                                const baseUrl = isDevelopment
-                                    ? "http://taris.sferadev.com:9004"
-                                    : "..";
 
                                 // Build "totals that do not match" table
                                 const calculatedNumericCells = [
@@ -1514,113 +1496,71 @@
                                             {
                                                 text: "Fix all incorrect values",
                                                 action: function (e, dt, node, config) {
-                                                    if (removeDataValues !== undefined) {
-                                                        $("#loading").show();
-                                                        this.disable();
-                                                        var removevaluescount =
-                                                            removeDataValues.length;
-                                                        getAllObjects(removeDataValues).then(
-                                                            function () {
-                                                                if (
-                                                                    correctDataValues !== undefined
-                                                                ) {
-                                                                    $.ajax({
-                                                                        type: "POST",
-                                                                        url:
-                                                                            baseUrl +
-                                                                            "/api/dataValueSets",
-                                                                        dataType: "json",
-                                                                        headers: {
-                                                                            Accept: "application/json",
-                                                                            "Content-Type":
-                                                                                "application/json",
-                                                                        },
-                                                                        data: JSON.stringify({
-                                                                            dataElementIdScheme:
-                                                                                "UID",
-                                                                            dataValues:
-                                                                                correctDataValues,
-                                                                            idScheme: "UID",
-                                                                            orgUnitIdScheme: "UID",
-                                                                        }),
-                                                                        xhrFields: {
-                                                                            withCredentials: true,
-                                                                        },
-                                                                        crossDomain: isDevelopment,
-                                                                        success: function (
-                                                                            response
-                                                                        ) {
-                                                                            console.log(response);
-                                                                            alert(
-                                                                                `Status: ${response.status}\n` +
-                                                                                    `Overview: ${response.description}\n` +
-                                                                                    `Import count: ${response.importCount.imported} imported, ${response.importCount.updated} updated, ${response.importCount.ignored} ignored and  ${deleted} deleted` +
-                                                                                    `\n${
-                                                                                        response.conflicts
-                                                                                            ? response.conflicts.map(
-                                                                                                  e =>
-                                                                                                      "CONFLICT: " +
-                                                                                                      e.value +
-                                                                                                      "\n"
-                                                                                              )
-                                                                                            : ""
-                                                                                    }`
-                                                                            );
-                                                                            $("#loading").hide();
-                                                                            location.reload();
-                                                                        },
-                                                                    });
-                                                                    this.disable();
-                                                                } else {
-                                                                    alert("Removed:  0's values");
-                                                                    this.disable();
-                                                                }
-                                                            }
-                                                        );
-                                                    } else if (correctDataValues !== undefined) {
-                                                        $.ajax({
-                                                            type: "POST",
-                                                            url: baseUrl + "/api/dataValueSets",
-                                                            dataType: "json",
-                                                            headers: {
-                                                                Accept: "application/json",
-                                                                "Content-Type": "application/json",
-                                                            },
-                                                            data: JSON.stringify({
-                                                                dataElementIdScheme: "UID",
-                                                                dataValues: correctDataValues,
-                                                                idScheme: "UID",
-                                                                orgUnitIdScheme: "UID",
-                                                            }),
-                                                            xhrFields: {
-                                                                withCredentials: true,
-                                                            },
-                                                            crossDomain: isDevelopment,
-                                                            success: function (response) {
-                                                                console.log(response);
-                                                                alert(
-                                                                    `Status: ${response.status}\n` +
-                                                                        `Overview: ${response.description}\n` +
-                                                                        `Import count: ${response.importCount.imported} imported, ${response.importCount.updated} updated, ${response.importCount.ignored} ignored and ${deleted} deleted\\n` +
-                                                                        `\n${
-                                                                            response.conflicts
-                                                                                ? response.conflicts.map(
-                                                                                      e =>
-                                                                                          "CONFLICT: " +
-                                                                                          e.value +
-                                                                                          "\n"
-                                                                                  )
-                                                                                : ""
-                                                                        }`
-                                                                );
-                                                                $("#loading").hide();
-                                                                location.reload();
-                                                            },
-                                                        });
-                                                        this.disable();
-                                                    } else {
+                                                    if (
+                                                        removeDataValues === undefined ||
+                                                        correctDataValues === undefined
+                                                    ) {
                                                         alert("Still loading data, please wait!");
+                                                        return;
                                                     }
+
+                                                    this.disable();
+                                                    $("#loading").show();
+
+                                                    const updates =
+                                                        updateDataValues(correctDataValues);
+
+                                                    const removals = updateDataValues(
+                                                        removeDataValues,
+                                                        "DELETE"
+                                                    );
+
+                                                    $.when(updates, removals).then(
+                                                        (...results) => {
+                                                            const result = results.reduce(
+                                                                (acc, cur) => ({
+                                                                    imported:
+                                                                        acc.imported +
+                                                                        cur.importCount.imported,
+                                                                    updated:
+                                                                        acc.updated +
+                                                                        cur.importCount.updated,
+                                                                    deleted:
+                                                                        acc.deleted +
+                                                                        cur.importCount.deleted,
+                                                                    ignored:
+                                                                        acc.ignored +
+                                                                        cur.importCount.ignored,
+                                                                    conflicts: [
+                                                                        ...acc.conflicts,
+                                                                        ...cur.conflicts,
+                                                                    ],
+                                                                }),
+                                                                {
+                                                                    imported: 0,
+                                                                    updated: 0,
+                                                                    deleted: 0,
+                                                                    ignored: 0,
+                                                                    conflicts: [],
+                                                                }
+                                                            );
+
+                                                            alert(
+                                                                `Import count: ${result.imported} imported, ${result.updated} updated, ${result.ignored} ignored and ${result.deleted} deleted\\n` +
+                                                                    `\n${result.conflicts.map(
+                                                                        e =>
+                                                                            "CONFLICT: " +
+                                                                            e.value +
+                                                                            "\n"
+                                                                    )}`
+                                                            );
+                                                            $("#loading").hide();
+                                                            location.reload();
+                                                        },
+                                                        () => {
+                                                            alert("Error fixing data values");
+                                                        }
+                                                    );
                                                 },
                                             },
                                         ],
@@ -1632,13 +1572,10 @@
                                 $.ajax({
                                     type: "GET",
                                     dataType: "json",
-                                    url:
-                                        baseUrl +
-                                        "/api/dataSets/Tu81BTLUuCT.json?fields=organisationUnits",
+                                    url: `${baseUrl}/api/dataSets/Tu81BTLUuCT.json?fields=organisationUnits`,
                                     xhrFields: {
                                         withCredentials: true,
                                     },
-                                    crossDomain: isDevelopment,
                                     success: function (data) {
                                         const orgUnits = data.organisationUnits
                                             .map(({ id }) => id)
@@ -1647,14 +1584,10 @@
                                         $.ajax({
                                             type: "GET",
                                             dataType: "json",
-                                            url:
-                                                baseUrl +
-                                                "/api/dataValueSets.json?dataSet=Tu81BTLUuCT&startDate=1970-01-01&endDate=2100-01-01&orgUnit=" +
-                                                orgUnits,
+                                            url: `${baseUrl}/api/dataValueSets.json?dataSet=Tu81BTLUuCT&startDate=1970-01-01&endDate=2100-01-01&orgUnit=${orgUnits}`,
                                             xhrFields: {
                                                 withCredentials: true,
                                             },
-                                            crossDomain: isDevelopment,
                                             success: function (data) {
                                                 const promises = _(data.dataValues)
                                                     .map(e => [
@@ -1667,10 +1600,9 @@
                                                     .chunk(250)
                                                     .map(e =>
                                                         $.get(
-                                                            baseUrl +
-                                                                "/api/metadata.json?fields=id,name&filter=id:in:[" +
-                                                                e.join(",") +
-                                                                "]"
+                                                            `${baseUrl}/api/metadata.json?fields=id,name&filter=id:in:[${e.join(
+                                                                ","
+                                                            )}]`
                                                         )
                                                     )
                                                     .value();
@@ -1725,6 +1657,7 @@
                                                                     )
                                                                 )
                                                                 .value();
+
                                                             const result_remove = _(
                                                                 _.keys(providedValues)
                                                             )
@@ -1772,7 +1705,7 @@
                                                                                 period.split(
                                                                                     "-"
                                                                                 )[1],
-                                                                            value: "undefined",
+                                                                            value: "Empty",
                                                                             originalValue:
                                                                                 providedValue,
                                                                             sum: total.children
@@ -1803,7 +1736,7 @@
                                                                                     return dataValue &&
                                                                                         dataValue.value
                                                                                         ? dataValue.value
-                                                                                        : "undefined";
+                                                                                        : "Empty";
                                                                                 })
                                                                                 .join(" + "),
                                                                         };
@@ -1813,6 +1746,7 @@
                                                                 })
                                                                 .compact()
                                                                 .value();
+
                                                             return result_remove;
                                                         })
                                                         .flatten()
@@ -1946,23 +1880,19 @@
                                                         .value();
 
                                                     correctDataValues = result;
-                                                    removeDataValues = result_remove;
-                                                    if (result_remove.length > 0) {
-                                                        result_remove.forEach(function (element) {
-                                                            module1TotalsTable.row.add([
-                                                                metadata[element.dataElement],
-                                                                metadata[
-                                                                    element.categoryOptionCombo
-                                                                ],
-                                                                element.period,
-                                                                metadata[element.orgUnit],
-                                                                `${element.sum} = ${element.value}`,
-                                                                element.originalValue + "",
-                                                            ]);
-                                                        });
-                                                    }
-                                                    result.forEach(function (element) {
-                                                        module1TotalsTable.row.add([
+                                                    removeDataValues = result_remove.map(
+                                                        element => ({
+                                                            dataElement: element.dataElement,
+                                                            categoryOptionCombo:
+                                                                element.categoryOptionCombo,
+                                                            period: element.period,
+                                                            orgUnit: element.orgUnit,
+                                                            value: 0,
+                                                        })
+                                                    );
+
+                                                    const rows = [...result, ...result_remove].map(
+                                                        element => [
                                                             metadata[element.dataElement],
                                                             metadata[element.categoryOptionCombo],
                                                             element.period,
@@ -1970,11 +1900,12 @@
                                                             `${element.sum} = ${element.value}`,
                                                             element.originalValue
                                                                 ? element.originalValue
-                                                                : "-",
-                                                        ]);
-                                                    });
-                                                    module1TotalsTable.draw();
+                                                                : "Empty",
+                                                        ]
+                                                    );
 
+                                                    module1TotalsTable.rows.add(rows);
+                                                    module1TotalsTable.draw();
                                                     $("#loading").hide();
                                                 });
                                             },

--- a/HWF/Reports/NHWA Auto-complete compute.html
+++ b/HWF/Reports/NHWA Auto-complete compute.html
@@ -1912,7 +1912,7 @@
                                                             `${element.sum} = ${element.value}`,
                                                             element.originalValue
                                                                 ? element.originalValue
-                                                                : "Empty",
+                                                                : "0",
                                                         ]
                                                     );
 

--- a/HWF/Reports/NHWA Auto-complete compute.html
+++ b/HWF/Reports/NHWA Auto-complete compute.html
@@ -524,14 +524,76 @@
                         <script src="https://cdn.datatables.net/buttons/1.6.0/js/dataTables.buttons.min.js"></script>
                         <script type="text/javascript">
                             var correctDataValues = undefined;
+                            var removeDataValues = undefined;
+							var deleted = 0;
+							const pagesize=500;
+														var getAllObjects = function (removeDataValues) {
+														var start = 0,
+														totalObjects = removeDataValues.length,
+														pushedObjects = 0,
+														chunkSize = pagesize,
+														dfd = $.Deferred(),
+														getChunk = function (start, chunkSize, pushedObjects, deleted) {
+														return $.ajax({
+                                                            url: ".." + "/api/dataValueSets?importStrategy=DELETE",
+															type: 'POST',
+															dataType: 'json',
+															data: JSON.stringify({
+																		dataElementIdScheme: "UID",
+																		dataValues: removeDataValues.slice(start, chunkSize),
+																		idScheme: "UID",
+																		orgUnitIdScheme: "UID",
+																	}),
+															xhrFields: {
+																		withCredentials: true,
+																	},
+															crossDomain: false,
+															contentType: 'application/json; charset=utf-8',
+															success: function (response){
+																		console.log(response);
+																		return response;
+																		},
+															error: function (e){
+															console.log(e);
+															return e;
+															}
+														});
+														},
+														recursiveGet = function () {
+															getChunk(start, chunkSize, pushedObjects, deleted).done(function (retVal) {
+																console.log(retVal);
+																if (retVal.status !== 'ERROR') {
+																		pushedObjects += pagesize;
+																		if (retVal.importCount && retVal.importCount.deleted){
+																			deleted = deleted + retVal.importCount.deleted;
+																		}
+																	if (totalObjects > pushedObjects) {
+																		start = start + pagesize;
+																		chunkSize = chunkSize + pagesize;
+																		recursiveGet();
+																	}
+																	else {
+																	console.log("finished: "+deleted);
+																		dfd.resolve();
+																	}
+																}
+																else {
+																	console.log("error: "+deleted);
+																	dfd.resolve();
+																}
+															});
+														};
+														recursiveGet();
+														return dfd;
+													};
                             $(document).ready(function () {
                                 const isDevelopment = false;
                                 const baseUrl = isDevelopment
                                     ? "http://taris.sferadev.com:9004"
                                     : "..";
 
-                                // Build "totals that do not match" table
-                                const calculatedNumericCells = [
+                                // Build "totals that do not match" table 
+								const calculatedNumericCells = [
                                     //Working Details
 
                                     //1 - Medical Doctors
@@ -1485,10 +1547,60 @@
                                             {
                                                 text: "Fix all incorrect values",
                                                 action: function (e, dt, node, config) {
-                                                    if (correctDataValues !== undefined) {
-                                                        $("#loading").show();
-                                                        console.log(correctDataValues);
-                                                        this.disable();
+												if(removeDataValues !==undefined){
+												
+                                                $("#loading").show();
+												this.disable();
+												var removevaluescount = removeDataValues.length;
+															getAllObjects(removeDataValues).then(function () { 
+															if (correctDataValues !== undefined) {
+																	
+																$.ajax({
+																	type: "POST",
+																	url: baseUrl + "/api/dataValueSets",
+																	dataType: "json",
+																	headers: {
+																		Accept: "application/json",
+																		"Content-Type": "application/json",
+																	},
+																	data: JSON.stringify({
+																		dataElementIdScheme: "UID",
+																		dataValues: correctDataValues,
+																		idScheme: "UID",
+																		orgUnitIdScheme: "UID",
+																	}),
+																	xhrFields: {
+																		withCredentials: true,
+																	},
+																	crossDomain: isDevelopment,
+																	success: function (response) {
+																		console.log(response);
+																		alert(
+																			`Status: ${response.status}\n` +
+																				`Overview: ${response.description}\n` +
+																				`Import count: ${response.importCount.imported} imported, ${response.importCount.updated} updated, ${response.importCount.ignored} ignored and  ${deleted} deleted` +
+																				`\n${
+																					response.conflicts
+																						? response.conflicts.map(
+																							  e =>
+																								  "CONFLICT: " +
+																								  e.value +
+																								  "\n"
+																						  )
+																						: ""
+																				}`
+																		);
+																		$("#loading").hide();
+																		location.reload();
+																	},
+																});
+																this.disable();
+															}else{
+																		alert("Removed:  0's values" );
+																		this.disable();
+															}							
+															});
+                                                    } else if (correctDataValues !== undefined){
                                                         $.ajax({
                                                             type: "POST",
                                                             url: baseUrl + "/api/dataValueSets",
@@ -1512,7 +1624,7 @@
                                                                 alert(
                                                                     `Status: ${response.status}\n` +
                                                                         `Overview: ${response.description}\n` +
-                                                                        `Import count: ${response.importCount.imported} imported, ${response.importCount.updated} updated and ${response.importCount.ignored} ignored\n` +
+                                                                        `Import count: ${response.importCount.imported} imported, ${response.importCount.updated} updated, ${response.importCount.ignored} ignored and ${deleted} deleted\\n` +
                                                                         `\n${
                                                                             response.conflicts
                                                                                 ? response.conflicts.map(
@@ -1529,7 +1641,8 @@
                                                             },
                                                         });
                                                         this.disable();
-                                                    } else {
+													}
+													else {
                                                         alert("Still loading data, please wait!");
                                                     }
                                                 },
@@ -1560,8 +1673,8 @@
                                             dataType: "json",
                                             url:
                                                 baseUrl +
-                                                "/api/dataValueSets.json?dataSet=Tu81BTLUuCT&startDate=1970-01-01&endDate=2100-01-01&orgUnit=" +
-                                                orgUnits,
+                                                //"/api/dataValueSets.json?dataSet=Tu81BTLUuCT&startDate=2010-01-01&endDate=2021-01-01&orgUnit=zFInPJBZVbN",
+                                                "/api/dataValueSets.json?dataSet=Tu81BTLUuCT&startDate=1970-01-01&endDate=2100-01-01&orgUnit=" + orgUnits,
                                             xhrFields: {
                                                 withCredentials: true,
                                             },
@@ -1599,6 +1712,146 @@
                                                             element =>
                                                                 `${element.dataElement}-${element.categoryOptionCombo}-val`
                                                         )
+                                                        .value();
+
+                                                    const result_remove = _(calculatedNumericCells)
+                                                        .map(total => {
+                                                            var providedValues = _(
+                                                                dataValues[total.id]
+                                                            )
+                                                                .groupBy(
+                                                                    element =>
+                                                                        `${element.period}-${element.orgUnit}-val`
+                                                                )
+                                                                .mapValues(values =>
+                                                                    _.sumBy(values, e =>
+                                                                        parseFloat(e.value)
+                                                                    )
+                                                                )
+                                                                .value();
+                                                            const calculatedValues2 = _(
+                                                                total.children
+                                                            )
+                                                                .map(e =>
+                                                                    !!dataValues[e]
+                                                                        ? dataValues[e]
+                                                                        : []
+                                                                )
+                                                                .flatten()
+                                                                .groupBy(
+                                                                    element =>
+                                                                        `${element.period}-${element.orgUnit}-val`
+                                                                )
+                                                                .mapValues(values =>
+                                                                    _.sumBy(values, e =>
+                                                                        parseFloat(e.value)
+                                                                    )
+                                                                )
+                                                                .value();
+
+                                                            const calculatedValues = _(
+                                                                total.children
+                                                            )
+                                                                .map(e =>
+                                                                    !!dataValues[e]
+                                                                        ? dataValues[e]
+                                                                        : []
+                                                                )
+                                                                .flatten()
+                                                                .groupBy(
+                                                                    element =>
+                                                                        `${element.period}-${element.orgUnit}-val`
+                                                                )
+                                                                .mapValues(values =>
+                                                                    _.sumBy(values, e =>
+                                                                        parseFloat(e.value || 0)
+                                                                    )
+                                                                )
+                                                                .value();
+                                                            const result_remove = _(_.keys(providedValues))
+                                                                .union(_.keys(calculatedValues))
+                                                                .map(period => {
+                                                                    const calculatedValue =
+                                                                        !isNaN(
+                                                                            calculatedValues[period]
+                                                                        ) &&
+                                                                        calculatedValues[period] ===
+                                                                            0
+                                                                            ? calculatedValues[
+                                                                                  period
+                                                                              ]
+                                                                            : undefined;
+
+                                                                    var providedValue =""
+																	if  (!isNaN(
+                                                                            providedValues[period]
+                                                                        )){
+																		providedValue = providedValues[period];
+																		}
+
+                                                                    if (calculatedValue === undefined && providedValue === 0  ) {
+                                                                        return {
+                                                                            dataElement:
+                                                                                total.id.split(
+                                                                                    "-"
+                                                                                )[0],
+                                                                            categoryOptionCombo:
+                                                                                total.id.split(
+                                                                                    "-"
+                                                                                )[1],
+                                                                            period: period.split(
+                                                                                "-"
+                                                                            )[0],
+                                                                            orgUnit:
+                                                                                period.split(
+                                                                                    "-"
+                                                                                )[1],
+                                                                            value:
+                                                                                0,
+                                                                            originalValue:
+                                                                                providedValue,
+                                                                            sum: total.children
+                                                                                .map(e => {
+                                                                                    const dataValue =
+                                                                                        _.find(
+                                                                                            dataValues[
+                                                                                                e
+                                                                                            ],
+                                                                                            {
+                                                                                                dataElement:
+                                                                                                    e.split(
+                                                                                                        "-"
+                                                                                                    )[0],
+                                                                                                categoryOptionCombo:
+                                                                                                    e.split(
+                                                                                                        "-"
+                                                                                                    )[1],
+                                                                                                period: period.split(
+                                                                                                    "-"
+                                                                                                )[0],
+                                                                                                orgUnit:
+                                                                                                    period.split(
+                                                                                                        "-"
+                                                                                                    )[1],
+                                                                                            }
+                                                                                        );
+                                                                                    return dataValue &&
+                                                                                        dataValue.value
+                                                                                        ? dataValue.value
+                                                                                        : 0;
+                                                                                })
+                                                                                .join(" + "),
+                                                                        };
+                                                                    } else {
+                                                                        return null;
+                                                                    }
+                                                                })
+                                                                .compact()
+                                                                .value();
+                                                            return result_remove;
+                                                        })
+                                                        .flatten()
+                                                        .compact()
                                                         .value();
 
                                                     const result = _(calculatedNumericCells)
@@ -1649,6 +1902,7 @@
                                                                                   period
                                                                               ]
                                                                             : undefined;
+
 
                                                                     const providedValue =
                                                                         !isNaN(
@@ -1728,8 +1982,20 @@
                                                         .value();
 
                                                     correctDataValues = result;
-
-                                                    result.forEach(function (element) {
+                                                    removeDataValues = result_remove;
+													if ( result_remove.length > 0 ){
+													result_remove.forEach(function (element) {
+                                                        module1TotalsTable.row.add([
+                                                            metadata[element.dataElement],
+                                                            metadata[element.categoryOptionCombo],
+                                                            element.period,
+                                                            metadata[element.orgUnit],
+                                                            `${element.sum} = ${element.value}`,
+															element.originalValue + "",
+                                                        ]);
+                                                    });
+													}
+													result.forEach(function (element) {
                                                         module1TotalsTable.row.add([
                                                             metadata[element.dataElement],
                                                             metadata[element.categoryOptionCombo],

--- a/HWF/Reports/NHWA Auto-complete compute.html
+++ b/HWF/Reports/NHWA Auto-complete compute.html
@@ -1517,35 +1517,38 @@
 
                                                     $.when(updates, removals).then(
                                                         (...results) => {
-                                                            const result = _.compact(
-                                                                results
-                                                            ).reduce(
-                                                                (acc, cur) => ({
-                                                                    imported:
-                                                                        acc.imported +
-                                                                        cur.importCount.imported,
-                                                                    updated:
-                                                                        acc.updated +
-                                                                        cur.importCount.updated,
-                                                                    deleted:
-                                                                        acc.deleted +
-                                                                        cur.importCount.deleted,
-                                                                    ignored:
-                                                                        acc.ignored +
-                                                                        cur.importCount.ignored,
-                                                                    conflicts: [
-                                                                        ...acc.conflicts,
-                                                                        ...cur.conflicts,
-                                                                    ],
-                                                                }),
-                                                                {
-                                                                    imported: 0,
-                                                                    updated: 0,
-                                                                    deleted: 0,
-                                                                    ignored: 0,
-                                                                    conflicts: [],
-                                                                }
-                                                            );
+                                                            const result = _(results)
+                                                                .flatten()
+                                                                .compact()
+                                                                .reduce(
+                                                                    (acc, cur) => ({
+                                                                        imported:
+                                                                            acc.imported +
+                                                                            cur.importCount
+                                                                                .imported,
+                                                                        updated:
+                                                                            acc.updated +
+                                                                            cur.importCount.updated,
+                                                                        deleted:
+                                                                            acc.deleted +
+                                                                            cur.importCount.deleted,
+                                                                        ignored:
+                                                                            acc.ignored +
+                                                                            cur.importCount.ignored,
+                                                                        conflicts: [
+                                                                            ...acc.conflicts,
+                                                                            ...cur.conflicts,
+                                                                        ],
+                                                                    }),
+                                                                    {
+                                                                        imported: 0,
+                                                                        updated: 0,
+                                                                        deleted: 0,
+                                                                        ignored: 0,
+                                                                        conflicts: [],
+                                                                    }
+                                                                )
+                                                                .value();
 
                                                             alert(
                                                                 `Import count: ${result.imported} imported, ${result.updated} updated, ${result.ignored} ignored and ${result.deleted} deleted\\n` +
@@ -1562,7 +1565,7 @@
                                                                 removals,
                                                                 results,
                                                             });
-                                                            
+
                                                             $("#loading").hide();
                                                             location.reload();
                                                         },

--- a/HWF/Reports/NHWA Auto-complete compute.html
+++ b/HWF/Reports/NHWA Auto-complete compute.html
@@ -1517,7 +1517,9 @@
 
                                                     $.when(updates, removals).then(
                                                         (...results) => {
-                                                            const result = results.reduce(
+                                                            const result = _.compact(
+                                                                results
+                                                            ).reduce(
                                                                 (acc, cur) => ({
                                                                     imported:
                                                                         acc.imported +
@@ -1554,6 +1556,13 @@
                                                                             "\n"
                                                                     )}`
                                                             );
+
+                                                            console.log({
+                                                                updates,
+                                                                removals,
+                                                                results,
+                                                            });
+                                                            
                                                             $("#loading").hide();
                                                             location.reload();
                                                         },

--- a/HWF/Reports/NHWA Auto-complete compute.html
+++ b/HWF/Reports/NHWA Auto-complete compute.html
@@ -62,6 +62,11 @@
             rel="stylesheet"
             type="text/css"
         />
+        <style type="text/css">
+		#mainPage {
+				margin: 5px 10px 10px 20px!important;
+            }
+        </style>
         <style>
             html {
                 font-size: 14px;
@@ -197,22 +202,6 @@
             type="text/javascript"
             src="../dhis-web-commons/javascripts/header-bar/header-bar.js?_rev=ce9c6db"
         ></script>
-        <script>
-            // Needs to be wrapped in jQuery to be sure the DOM is parsed as the script is not at the bottom.
-            jQuery(function () {
-                try {
-                    if ("Dhis2HeaderBar" in window) {
-                        Dhis2HeaderBar.initHeaderBar(document.querySelector("#header"), undefined, {
-                            noLoadingIndicator: true,
-                        });
-                    }
-                } catch (e) {
-                    if ("console" in window) {
-                        console.error(e);
-                    }
-                }
-            });
-        </script>
         <!-- // End menu -->
         <!--[if lte IE 8
             ]><script
@@ -432,30 +421,6 @@
     </head>
 
     <body>
-        <div id="header">
-            <img
-                id="headerBanner"
-                src="../api/staticContent/logo_banner"
-                onclick="window.location.href='../dhis-web-commons-about/redirect.action'"
-                style="cursor: pointer"
-                title="View home page"
-            />
-
-            <div id="dhisDropDownMenu"></div>
-        </div>
-        <span id="showLeftBar">
-            <a href="javascript:dhis2.leftBar.showAnimated()" title="Show menu">
-                <i class="fa fa-arrow-right leftBarIcon"></i>
-            </a>
-        </span>
-
-        <style type="text/css">
-            #mainPage {
-                margin-left: 20px;
-            }
-        </style>
-
-        <div id="headerMessage" class="bold"></div>
 
         <div class="page" id="mainPage">
             <script type="text/javascript">
@@ -1689,7 +1654,6 @@
                                             dataType: "json",
                                             url:
                                                 baseUrl +
-                                                //"/api/dataValueSets.json?dataSet=Tu81BTLUuCT&startDate=2010-01-01&endDate=2021-01-01&orgUnit=zFInPJBZVbN",
                                                 "/api/dataValueSets.json?dataSet=Tu81BTLUuCT&startDate=1970-01-01&endDate=2100-01-01&orgUnit=" +
                                                 orgUnits,
                                             xhrFields: {
@@ -1736,25 +1700,6 @@
                                                             var providedValues = _(
                                                                 dataValues[total.id]
                                                             )
-                                                                .groupBy(
-                                                                    element =>
-                                                                        `${element.period}-${element.orgUnit}-val`
-                                                                )
-                                                                .mapValues(values =>
-                                                                    _.sumBy(values, e =>
-                                                                        parseFloat(e.value)
-                                                                    )
-                                                                )
-                                                                .value();
-                                                            const calculatedValues2 = _(
-                                                                total.children
-                                                            )
-                                                                .map(e =>
-                                                                    !!dataValues[e]
-                                                                        ? dataValues[e]
-                                                                        : []
-                                                                )
-                                                                .flatten()
                                                                 .groupBy(
                                                                     element =>
                                                                         `${element.period}-${element.orgUnit}-val`
@@ -1832,7 +1777,7 @@
                                                                                 period.split(
                                                                                     "-"
                                                                                 )[1],
-                                                                            value: 0,
+                                                                            value: "undefined",
                                                                             originalValue:
                                                                                 providedValue,
                                                                             sum: total.children
@@ -1863,7 +1808,7 @@
                                                                                     return dataValue &&
                                                                                         dataValue.value
                                                                                         ? dataValue.value
-                                                                                        : 0;
+                                                                                        : "undefined";
                                                                                 })
                                                                                 .join(" + "),
                                                                         };


### PR DESCRIPTION
Added remove zero values from totals when the childres doesnt have any value.

I have installed the report in dev dev-cont and preprod.

Note: We have added pagination for the zero values, if in the future we have many values to recalculate we may need to implement this solution to limit the values sent in each call.

I also remove the duplicate header, its unnecesary in 2.34 and loosk broken in 2.36.

@SferaDev please don't click in the button to fix the values in dev or preprod due the hwf team could need validate them.